### PR TITLE
Allow to modify page content fields and the structure of a content elements bodytext for indexing custom content elements

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -330,6 +330,17 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types {
 	public function getPageContent($uid) {
 		// get content elements for this page
 		$fields = 'uid, pid, header, bodytext, CType, sys_language_uid, header_layout, fe_group';
+
+		// hook to modify the page content fields
+		if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyPageContentFields'])) {
+			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyPageContentFields'] as $_classRef) {
+				$_procObj = & \TYPO3\CMS\Core\Utility\GeneralUtility::getUserObj($_classRef);
+				$_procObj->modifyPageContentFields(
+					$fields, $this
+				);
+			}
+		}
+
 		$table = 'tt_content';
 		$where = 'pid = ' . intval($uid);
 		$where .= ' AND (' . $this->whereClauseForCType . ')';
@@ -763,6 +774,17 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types {
 			$bodytext = str_replace('|', ' ', $bodytext);
 		}
 		$bodytext = strip_tags($bodytext);
+
+		// hook for modifiying a content elements content
+		if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyContentFromContentElement'])) {
+			foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyContentFromContentElement'] as $_classRef) {
+				$_procObj = & \TYPO3\CMS\Core\Utility\GeneralUtility::getUserObj($_classRef);
+				$_procObj->modifyContentFromContentElement(
+					$bodytext, $ttContentRow, $this
+				);
+			}
+		}
+
 		return $bodytext;
 	}
 


### PR DESCRIPTION
Two new hooks which would allow to customize the indexing of content elements.

Example usage:

```
namespace FelixJacobi\SitePackage\Hooks;

class SearchExtension
{
    public function modifyPageContentFields(&$fields, $pObj)
    {
        $fields .= ', subheader';
    }

    public function modifyContentFromContentElement(&$bodytext, &$ttContentRow, $pObj)
    {
        $bodytext = $ttContentRow['subheader'] . $bodytext;
    }

}
```
