### PR TITLE
News indexer should be able to differentiate between active and archived news

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_news.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_news.php
@@ -65,8 +65,10 @@ class tx_kesearch_indexer_types_news extends tx_kesearch_indexer_types {
 		$fields = '*';
 		$where = 'pid IN (' . implode(',', $indexPids) . ') ';
 
-		if(!$this->indexerConfig['index_news_archived']) {
+		if($this->indexerConfig['index_news_archived'] == 1) {
 			$where .= 'AND ( archive = 0 OR archive > ' . time() . ') ';
+		} elseif($this->indexerConfig['index_news_archived'] == 2) {
+			$where .= 'AND ( archive > 0 AND archive < ' . time() . ') ';
 		}
 
 		$where .= \TYPO3\CMS\Backend\Utility\BackendUtility::BEenableFields($table);

--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -398,7 +398,7 @@ $configurationArray = array(
         ),
     ),
     'types' => array(
-        '0' => array('showitem' => 'hidden;;1;;1-1-1, title;;;;2-2-2, storagepid,targetpid;;;;3-3-3,type,startingpoints_recursive,single_pages,sysfolder,index_content_with_restrictions,index_passed_events,index_news_category_mode,index_news_archived,index_news_category_selection,index_extnews_category_selection,index_news_useHRDatesSingle,index_news_useHRDatesSingleWithoutDay,index_use_page_tags,fal_storage,directories,fileext,contenttypes,commenttypes,filteroption,tvpath,index_use_page_tags_for_files')
+        '0' => array('showitem' => 'hidden;;1;;1-1-1, title;;;;2-2-2, storagepid,targetpid;;;;3-3-3,type,startingpoints_recursive,single_pages,sysfolder,index_content_with_restrictions,index_passed_events,index_news_archived,index_news_category_mode,index_news_category_selection,index_extnews_category_selection,index_news_useHRDatesSingle,index_news_useHRDatesSingleWithoutDay,index_use_page_tags,fal_storage,directories,fileext,contenttypes,commenttypes,filteroption,tvpath,index_use_page_tags_for_files')
     ),
     'palettes' => array(
         '1' => array('showitem' => '')


### PR DESCRIPTION
- adds a new field to the news indexer configuration

Tested on 7.6.0 with a small sample of news (10).
