### PR TITLE
[BUGFIX] Prevent error in result list when file is missing

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -1100,9 +1100,7 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 
 			// if index record is of type "file" and contains an orig_uid, this is the reference
 			// to a FAL record. Otherwise we use the path directly.
-			if ($row['orig_uid']) {
-				$fileRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
-				$fileObject = $fileRepository->findByUid($row['orig_uid']);
+			if ($row['orig_uid'] && ($fileObject = tx_kesearch_helper::getFile($row['orig_uid']))) {
 				$metadata = $fileObject->_getMetaData();
 				$imageConf['file'] = $fileObject->getPublicUrl();
 				$imageConf['altText'] = $metadata['alternative'];

--- a/Classes/lib/class.tx_kesearch_lib_helper.php
+++ b/Classes/lib/class.tx_kesearch_lib_helper.php
@@ -22,6 +22,8 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+
 /**
  * helper functions
  * must be used used statically!
@@ -202,10 +204,7 @@ class tx_kesearch_helper {
 			case 'file':
 				// render a link for files
 				// if we use FAL, we can use the API
-				if ($resultRow['orig_uid']) {
-					/* @var $fileRepository TYPO3\CMS\Core\Resource\FileRepository */
-					$fileRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
-					$fileObject = $fileRepository->findByUid($resultRow['orig_uid']);
+				if ($resultRow['orig_uid'] && ($fileObject = tx_kesearch_helper::getFile($resultRow['orig_uid']))) {
 					$linkconf['parameter'] = $fileObject->getPublicUrl();
 				} else {
 					$linkconf['parameter'] = $resultRow['directory'] . rawurlencode($resultRow['title']);
@@ -235,5 +234,22 @@ class tx_kesearch_helper {
 		}
 
 		return $linkconf;
+	}
+
+	/**
+	 *
+	 * @param  integer $uid
+	 * @return File|NULL
+	 */
+	public static function getFile($uid) {
+
+		try {
+			$fileObject = ResourceFactory::getInstance()->getFileObject($uid);
+		} catch (\TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException $e) {
+			$fileObject = NULL;
+		}
+
+		return $fileObject;
+
 	}
 }

--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -99,9 +99,7 @@ class tx_kesearch_lib_searchresult {
 		switch($type) {
 			case 'file':
 				// if we use FAL, see if we have a title in the metadata
-				if ($this->row['orig_uid']) {
-					$fileRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
-					$fileObject = $fileRepository->findByUid($this->row['orig_uid']);
+				if ($this->row['orig_uid'] && ($fileObject = tx_kesearch_helper::getFile($this->row['orig_uid']))) {
 					$metadata = $fileObject->_getMetaData();
 					$linktext = ($metadata['title'] ? $metadata['title'] : $this->row['title']);
 				} else {


### PR DESCRIPTION
Files removed vom FAL after the last index run lead to a FileNotFoundError in the search result list - which is bad from a user and SEO point of view.

This PR catches the error and displays only the result text (without preview of course) until it can be removed by re-indexing.

Still not the best option since the broken file link is still there - but at least it leads to a proper 404 error instead of a 500.
