### PR TITLE
Change contenttypes to text to allow a greater list of content elements

### DIFF
--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -396,8 +396,10 @@ $configurationArray = array(
             'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.contenttypes',
             'displayCond' => 'FIELD:type:IN:page,tt_content',
             'config' => array(
-                'type' => 'input',
-                'size' => '30',
+                'type' => 'text',
+                'cols' => 48,
+                'rows' => 10,
+                'eval' => 'trim',
                 'default' => 'text,textmedia,textpic,bullets,table,html,header,uploads'
             )
         ),

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -131,7 +131,7 @@ CREATE TABLE tx_kesearch_indexerconfig (
 	filteroption int(11) DEFAULT '0' NOT NULL,
 	tvpath varchar(255) DEFAULT '' NOT NULL,
 	fal_storage int(11) DEFAULT '0' NOT NULL,
-	contenttypes tinytext,
+	contenttypes text,
 	cal_expired_events tinyint(3) DEFAULT '0' NOT NULL,
 
 	PRIMARY KEY (uid),


### PR DESCRIPTION
In one of our projects we have a lot of custom CEs and we needed a bigger listfield.
I don't know if this is a common thing or specific to us, so feel free to deny it, if you think that this is a special case.
