### PR TITLE
Set correct fileinfo for file references

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -608,7 +608,7 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types {
 					// count indexed files, add it to the indexer output
 					if (!file_exists($filePath)) {
 						$this->addError('Could not index file ' . $filePath . ' (file does not exist).');
-					} else if ($fileIndexerObject->fileInfo->setFile($filePath)) {
+					} else if ($fileIndexerObject->fileInfo->setFile($fileObject)) {
 						if (($content = $fileIndexerObject->getFileContent($filePath))) {
 							$this->storeFileContentToIndex($fileObject, $content, $fileIndexerObject, $feGroups, $tags, $ttContentRow);
 							$this->fileCounter++;

--- a/Classes/lib/class.tx_kesearch_lib_fileinfo.php
+++ b/Classes/lib/class.tx_kesearch_lib_fileinfo.php
@@ -48,7 +48,7 @@ class tx_kesearch_lib_fileinfo {
 	/**
 	 * set a filename to get informations of
 	 *
-	 * @param string|\TYPO3\CMS\Core\Resource\File $file
+	 * @param string|\TYPO3\CMS\Core\Resource\File|\TYPO3\CMS\Core\Resource\FileReference $file
 	 * @return boolean is valid file
 	 */
 	public function setFile($file) {
@@ -64,7 +64,12 @@ class tx_kesearch_lib_fileinfo {
 	 */
 	protected function setFileInformations($file) {
 		$this->fileInfo = array(); // reset previously information to have a cleaned object
-		$this->file = $file instanceof \TYPO3\CMS\Core\Resource\File ? $file : NULL;
+		if ($file instanceof \TYPO3\CMS\Core\Resource\File) {
+			$this->file = $file;
+		}
+		elseif ($file instanceof \TYPO3\CMS\Core\Resource\FileReference) {
+			$this->file = $file = $file->getOriginalFile();
+		}
 
 		if(is_string($file) && !empty($file)) {
 			$this->fileInfo = TYPO3\CMS\Core\Utility\GeneralUtility::split_fileref($file);


### PR DESCRIPTION
Currently, indexing files attached to content elements via file references generates a different unique file hash than for the same file directly indexed, resulting in duplicate search results for these files. This patch fixes this.
