### PR TITLE
[CONFIG] Enable changing doc_type in page indexer

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -152,6 +152,10 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types {
 			$content_types_temp = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->indexerConfig['contenttypes']);
 		}
 
+		if(!empty($this->indexerConfig['index_page_doctypes'])){
+			$this->indexDokTypes =  \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->indexerConfig['index_page_doctypes']);
+		}
+
 		// create a mysql WHERE clause for the content element types
 		$cTypes = array();
 		foreach ($content_types_temp as $value) {

--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -17,7 +17,7 @@ $configurationArray = array(
         'requestUpdate' => 'type'
     ),
     'interface' => array(
-        'showRecordFieldList' => 'hidden,title,storagepid,startingpoints_recursive,single_pages,sysfolder,type,index_content_with_restrictions,index_passed_events,,index_news_category_mode,index_news_category_selection,directories,fileext,filteroption'
+        'showRecordFieldList' => 'hidden,title,storagepid,startingpoints_recursive,single_pages,sysfolder,type,index_content_with_restrictions,index_passed_events,,index_news_category_mode,index_news_category_selection,directories,fileext,filteroption,index_page_doctypes'
     ),
     'columns' => array(
         'hidden' => array(
@@ -364,6 +364,15 @@ $configurationArray = array(
                 'default' => '0'
             )
         ),
+        'index_page_doctypes' => array(
+            'exclude' => 0,
+            'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.index_page_doctypes',
+            'displayCond' => 'FIELD:type:=:page',
+            'config' => array(
+                'type' => 'input',
+                'size' => '30',
+            )
+        ),
         'commenttypes' => array(
             'exclude' => 0,
             'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.commenttypes',
@@ -439,7 +448,7 @@ $configurationArray = array(
         )
     ),
     'types' => array(
-        '0' => array('showitem' => 'hidden;;1;;1-1-1, title;;;;2-2-2, storagepid,targetpid;;;;3-3-3,type,startingpoints_recursive,single_pages,sysfolder,index_content_with_restrictions,index_passed_events,index_news_archived,index_news_category_mode,index_news_category_selection,index_extnews_category_selection,index_news_useHRDatesSingle,index_news_useHRDatesSingleWithoutDay,index_use_page_tags,fal_storage,directories,fileext,contenttypes,commenttypes,filteroption,tvpath,index_use_page_tags_for_files,cal_expired_events')
+        '0' => array('showitem' => 'hidden;;1;;1-1-1, title;;;;2-2-2, storagepid,targetpid;;;;3-3-3,type,startingpoints_recursive,single_pages,sysfolder,index_page_doctypes,index_content_with_restrictions,index_passed_events,index_news_archived,index_news_category_mode,index_news_category_selection,index_extnews_category_selection,index_news_useHRDatesSingle,index_news_useHRDatesSingleWithoutDay,index_use_page_tags,fal_storage,directories,fileext,contenttypes,commenttypes,filteroption,tvpath,index_use_page_tags_for_files,cal_expired_events')
     ),
     'palettes' => array(
         '1' => array('showitem' => '')

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -125,6 +125,7 @@ CREATE TABLE tx_kesearch_indexerconfig (
 	index_news_useHRDatesSingleWithoutDay tinyint(4) DEFAULT '0' NOT NULL,
 	index_use_page_tags tinyint(3) DEFAULT '0' NOT NULL,
 	index_use_page_tags_for_files tinyint(3) DEFAULT '0' NOT NULL,
+	index_page_doctypes varchar(255) DEFAULT '' NOT NULL,
 	directories text,
 	fileext tinytext,
 	commenttypes tinytext,

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -79,6 +79,7 @@
 			<label index="tx_kesearch_indexerconfig.index_use_page_tags_for_files">Add tags to files also?</label>
 			<label index="tx_kesearch_indexerconfig.index_passed_events.I.0">Yes</label>
 			<label index="tx_kesearch_indexerconfig.index_passed_events.I.1">No</label>
+			<label index="tx_kesearch_indexerconfig.index_page_doctypes">Index pages only with docTypes (default: 1,2,5):</label>
 			<label index="tx_kesearch_indexerconfig.directories">Directories (comma-separated, e.g. fileadmin/my_directory/,fileadmin/my_other_directory or my_directory/,my_other_directory/ if you use FAL)</label>
 			<label index="tx_kesearch_indexerconfig.fileext">File indexer: Comma separated list of allowed file extensions (eg. pdf,ppt,doc,xls):</label>
 			<label index="tx_kesearch_indexerconfig.contenttypes">Content element types which should be indexed (default: text,textpic,bullets,table,html,header,uploads):</label>
@@ -162,6 +163,7 @@
 			<label index="tx_kesearch_indexerconfig.index_use_page_tags_for_files">Schlagworte auch für Dateien übernehmen?</label>
 			<label index="tx_kesearch_indexerconfig.index_passed_events.I.0">Ja</label>
 			<label index="tx_kesearch_indexerconfig.index_passed_events.I.1">Nein</label>
+			<label index="tx_kesearch_indexerconfig.index_page_doctypes">Es werden Seiten nur mit den folenden Dokumenttypen indexiert (default: 1,2,5):</label>
 			<label index="tx_kesearch_indexerconfig.directories">Verzeichnisse (komma-getrennt, z. B. fileadmin/my_directory/,fileadmin/my_other_directory  oder my_directory/,my_other_directory/ bei FAL-Benutzung)</label>
 			<label index="tx_kesearch_indexerconfig.fileext">Datei-Indexer: Komma-separierte Liste von zu indexierenden Dateiendungen (z.B. pdf,ppt,doc,xls):</label>
 			<label index="tx_kesearch_indexerconfig.commenttypes">Komma-separierte Liste von zu indexierenden Kommentartypen (pages):</label>


### PR DESCRIPTION
Adding an extra field in page indexer
- comma separated list
- only visible if type=page
- default value is 1,2,5 (not visible in field)
