### PR TITLE
Doubled content in the teaser

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -273,8 +273,7 @@ class tx_kesearch_lib_searchresult {
 				// after last cropping our text is too short now. So we have to find a new cutting position
 				($startPos > 10)? $length = strlen($temp) - 10: $length = strlen($temp);
 				$croppedTeaser = $this->cObj->crop($temp, '-' . $length . '||1');
-				if(!in_array($croppedTeaser, $teaserArray))
-				{
+				if(!in_array($croppedTeaser, $teaserArray)) {
 					$teaserArray[] = $croppedTeaser;
 				}
 			}

--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -242,6 +242,7 @@ class tx_kesearch_lib_searchresult {
 			$charsBeforeAfterSearchWord = ceil($charsForEachSearchWord / 2);
 			$aSearchWordWasFound = FALSE;
 			$isSearchWordAtTheBeginning = FALSE;
+			$teaserArray = array();
 			foreach($this->pObj->swords as $word) {
 				$word = ' ' . $word; // our searchengine searches for wordbeginnings
 				$pos = stripos($content, $word);
@@ -271,7 +272,11 @@ class tx_kesearch_lib_searchresult {
 				// crop some words before searchword
 				// after last cropping our text is too short now. So we have to find a new cutting position
 				($startPos > 10)? $length = strlen($temp) - 10: $length = strlen($temp);
-				$teaserArray[] = $this->cObj->crop($temp, '-' . $length . '||1');
+				$croppedTeaser = $this->cObj->crop($temp, '-' . $length . '||1');
+				if(in_array($croppedTeaser, $teaserArray))
+				{
+					$teaserArray[] = $croppedTeaser;
+				}
 			}
 
 			// When the searchword was found in title but not in content the teaser is empty

--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -273,7 +273,7 @@ class tx_kesearch_lib_searchresult {
 				// after last cropping our text is too short now. So we have to find a new cutting position
 				($startPos > 10)? $length = strlen($temp) - 10: $length = strlen($temp);
 				$croppedTeaser = $this->cObj->crop($temp, '-' . $length . '||1');
-				if(in_array($croppedTeaser, $teaserArray))
+				if(!in_array($croppedTeaser, $teaserArray))
 				{
 					$teaserArray[] = $croppedTeaser;
 				}


### PR DESCRIPTION
I had a problem with searching for contacts in one of our projects and doubled teaser text. 
E.g.:
Contact John Doe
John Doe; Company; Department; Position John Doe; Company; Department; Position

Search phrase was: John Doe

The change prevents adding identical cropped teasers. 
This is another of those specific fixes I am not sure if they're needed by everyone. 
