### PR TITLE
[FEATURE] Add two options to tt_address indexer to link the url in result text

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_tt_address.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_tt_address.php
@@ -101,7 +101,20 @@ class tx_kesearch_indexer_types_tt_address extends tx_kesearch_indexer_types {
 			if (!empty($addressRow['phone']))   $content .= $addressRow['phone'] . "\n";
 			if (!empty($addressRow['fax']))     $content .= $addressRow['fax'] . "\n";
 			if (!empty($addressRow['mobile']))  $content .= $addressRow['mobile'] . "\n";
-			if (!empty($addressRow['www']))     $content .= $addressRow['www'];
+			if (!empty($addressRow['www'])) {
+				if ($this->indexerConfig['index_ttaddress_link_url']) {
+					$scheme = parse_url($addressRow['www'], PHP_URL_SCHEME);
+					if ($scheme === null) {
+						$uri = 'http://' . $addressRow['www'];
+					}
+
+					/** @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $cObj */
+					$cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+					$content .= $cObj->typoLink($addressRow['www'], array('parameter' => $uri, 'extTarget' => $this->indexerConfig['index_ttaddress_link_target']));
+				} else {
+					$content .= $addressRow['www'];
+				}
+			}
 
 			// put content together
 			$fullContent = $abstract . "\n" . $content;

--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -17,7 +17,7 @@ $configurationArray = array(
         'requestUpdate' => 'type'
     ),
     'interface' => array(
-        'showRecordFieldList' => 'hidden,title,storagepid,startingpoints_recursive,single_pages,sysfolder,type,index_content_with_restrictions,index_passed_events,,index_news_category_mode,index_news_category_selection,directories,fileext,filteroption'
+        'showRecordFieldList' => 'hidden,title,storagepid,startingpoints_recursive,single_pages,sysfolder,type,index_content_with_restrictions,index_passed_events,index_ttaddress_link_url,index_ttaddress_link_target,index_news_category_mode,index_news_category_selection,directories,fileext,filteroption'
     ),
     'columns' => array(
         'hidden' => array(
@@ -214,6 +214,26 @@ $configurationArray = array(
                 'maxitems' => 1,
             )
         ),
+        'index_ttaddress_link_url' => array(
+            'exclude' => 0,
+            'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.index_ttaddress_link_url',
+            'displayCond' => 'FIELD:type:IN:tt_address',
+            'config' => array(
+                'type' => 'check',
+                'default' => true
+            ),
+        ),
+        'index_ttaddress_link_target' => array(
+            'exclude' => 0,
+            'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.index_ttaddress_link_target',
+            'displayCond' => 'FIELD:type:IN:tt_address',
+            'config' => array(
+                'type' => 'input',
+                'default' => '_blank',
+                'size' => 30,
+                'eval' => 'trim'
+            ),
+        ),
         'index_news_category_mode' => array(
             'exclude' => 0,
             'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.index_news_category_mode',
@@ -398,7 +418,7 @@ $configurationArray = array(
         ),
     ),
     'types' => array(
-        '0' => array('showitem' => 'hidden;;1;;1-1-1, title;;;;2-2-2, storagepid,targetpid;;;;3-3-3,type,startingpoints_recursive,single_pages,sysfolder,index_content_with_restrictions,index_passed_events,index_news_archived,index_news_category_mode,index_news_category_selection,index_extnews_category_selection,index_news_useHRDatesSingle,index_news_useHRDatesSingleWithoutDay,index_use_page_tags,fal_storage,directories,fileext,contenttypes,commenttypes,filteroption,tvpath,index_use_page_tags_for_files')
+        '0' => array('showitem' => 'hidden;;1;;1-1-1, title;;;;2-2-2, storagepid,targetpid;;;;3-3-3,type,startingpoints_recursive,single_pages,sysfolder,index_content_with_restrictions,index_passed_events,index_ttaddress_link_url,index_ttaddress_link_target,index_news_archived,index_news_category_mode,index_news_category_selection,index_extnews_category_selection,index_news_useHRDatesSingle,index_news_useHRDatesSingleWithoutDay,index_use_page_tags,fal_storage,directories,fileext,contenttypes,commenttypes,filteroption,tvpath,index_use_page_tags_for_files')
     ),
     'palettes' => array(
         '1' => array('showitem' => '')

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -117,6 +117,8 @@ CREATE TABLE tx_kesearch_indexerconfig (
 	index_content_with_restrictions text,
 	index_passed_events text,
 	type varchar(90) DEFAULT '' NOT NULL,
+	index_ttaddress_link_url tinyint(4) DEFAULT '1' NOT NULL,
+	index_ttaddress_link_target tinytext,
 	index_news_category_mode tinyint(4) DEFAULT '0' NOT NULL,
 	index_news_category_selection text,
 	index_extnews_category_selection text,

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -65,6 +65,8 @@
 			<label index="tx_kesearch_indexerconfig.index_content_with_restrictions.I.0">Yes</label>
 			<label index="tx_kesearch_indexerconfig.index_content_with_restrictions.I.1">No</label>
 			<label index="tx_kesearch_indexerconfig.index_passed_events">Index passed events?</label>
+			<label index="tx_kesearch_indexerconfig.index_ttaddress_link_url">Link URL in result text?</label>
+			<label index="tx_kesearch_indexerconfig.index_ttaddress_link_target">Target of link</label>
 			<label index="tx_kesearch_indexerconfig.index_news_category_mode">Index only news of the following categories:</label>
 			<label index="tx_kesearch_indexerconfig.index_news_category_mode.I.1">All</label>
 			<label index="tx_kesearch_indexerconfig.index_news_category_mode.I.2">Only the following categories:</label>


### PR DESCRIPTION
index_ttaddress_link_url, checkbox
when enabled the url gets wrapped with link in result text. default: checked

index_ttaddress_link_target, input
controls the target attribute of link. default: _blank
