### PR TITLE
Make external tools work w/ UTF-8 file names by using CommandUtility::escapeShellArgument()…

### DIFF
--- a/Classes/indexer/filetypes/class.tx_kesearch_indexer_filetypes_doc.php
+++ b/Classes/indexer/filetypes/class.tx_kesearch_indexer_filetypes_doc.php
@@ -23,6 +23,9 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  * ************************************************************* */
 
+use TYPO3\CMS\Core\Utility\CommandUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Plugin 'Faceted search' for the 'ke_search' extension.
  *
@@ -74,18 +77,19 @@ class tx_kesearch_indexer_filetypes_doc extends tx_kesearch_indexer_types_file i
 	 */
 	public function getContent($file) {
 		// create the tempfile which will contain the content
-		$tempFileName = TYPO3\CMS\Core\Utility\GeneralUtility::tempnam('doc_files-Indexer');
+		$tempFileName = GeneralUtility::tempnam('doc_files-Indexer');
 
 		// Delete if exists, just to be safe.
 		@unlink($tempFileName);
 
 		// generate and execute the pdftotext commandline tool
-		$cmd = $this->app['catdoc'] . ' -s8859-1 -dutf-8 ' . escapeshellarg($file) . ' > ' . escapeshellarg($tempFileName);
-		TYPO3\CMS\Core\Utility\CommandUtility::exec($cmd);
+		$fileEscaped = CommandUtility::escapeShellArgument($file);
+		$cmd = "{$this->app['catdoc']} -s8859-1 -dutf-8 $fileEscaped > $tempFileName";
+		CommandUtility::exec($cmd);
 
 		// check if the tempFile was successfully created
 		if (@is_file($tempFileName)) {
-			$content = TYPO3\CMS\Core\Utility\GeneralUtility::getUrl($tempFileName);
+			$content = GeneralUtility::getUrl($tempFileName);
 			unlink($tempFileName);
 		}
 		else

--- a/Classes/indexer/filetypes/class.tx_kesearch_indexer_filetypes_ppt.php
+++ b/Classes/indexer/filetypes/class.tx_kesearch_indexer_filetypes_ppt.php
@@ -23,6 +23,9 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  * ************************************************************* */
 
+use TYPO3\CMS\Core\Utility\CommandUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Plugin 'Faceted search' for the 'ke_search' extension.
  *
@@ -71,18 +74,19 @@ class tx_kesearch_indexer_filetypes_ppt extends tx_kesearch_indexer_types_file i
 	 */
 	public function getContent($file) {
 		// create the tempfile which will contain the content
-		$tempFileName = TYPO3\CMS\Core\Utility\GeneralUtility::tempnam('ppt_files-Indexer');
+		$tempFileName = GeneralUtility::tempnam('ppt_files-Indexer');
 
 		// Delete if exists, just to be safe.
 		@unlink($tempFileName);
 
 		// generate and execute the pdftotext commandline tool
-		$cmd = $this->app['catppt'] . ' -s8859-1 -dutf-8 ' . escapeshellarg($file) . ' > ' . escapeshellarg($tempFileName);
-		TYPO3\CMS\Core\Utility\CommandUtility::exec($cmd);
+		$fileEscaped = CommandUtility::escapeShellArgument($file);
+		$cmd = "{$this->app['catppt']} -s8859-1 -dutf-8 $fileEscaped > $tempFileName";
+		CommandUtility::exec($cmd);
 
 		// check if the tempFile was successfully created
 		if (@is_file($tempFileName)) {
-			$content = TYPO3\CMS\Core\Utility\GeneralUtility::getUrl($tempFileName);
+			$content = GeneralUtility::getUrl($tempFileName);
 			unlink($tempFileName);
 		}
 		else

--- a/Classes/indexer/filetypes/class.tx_kesearch_indexer_filetypes_xls.php
+++ b/Classes/indexer/filetypes/class.tx_kesearch_indexer_filetypes_xls.php
@@ -23,6 +23,9 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  * ************************************************************* */
 
+use TYPO3\CMS\Core\Utility\CommandUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Plugin 'Faceted search' for the 'ke_search' extension.
  *
@@ -72,18 +75,19 @@ class tx_kesearch_indexer_filetypes_xls extends tx_kesearch_indexer_types_file i
 	 */
 	public function getContent($file) {
 		// create the tempfile which will contain the content
-		$tempFileName = TYPO3\CMS\Core\Utility\GeneralUtility::tempnam('xls_files-Indexer');
+		$tempFileName = GeneralUtility::tempnam('xls_files-Indexer');
 
 		// Delete if exists, just to be safe.
 		@unlink($tempFileName);
 
 		// generate and execute the pdftotext commandline tool
-		$cmd = $this->app['xls2csv'] . ' -c \' \' -q 0 -s8859-1 -dutf-8 ' . escapeshellarg($file) . ' > ' . escapeshellarg($tempFileName);
-		TYPO3\CMS\Core\Utility\CommandUtility::exec($cmd);
+		$fileEscaped = CommandUtility::escapeShellArgument($file);
+		$cmd = "{$this->app['xls2csv']} -c ' ' -q 0 -s8859-1 -dutf-8 $fileEscaped > $tempFileName";
+		CommandUtility::exec($cmd);
 
 		// check if the tempFile was successfully created
 		if (@is_file($tempFileName)) {
-			$content = TYPO3\CMS\Core\Utility\GeneralUtility::getUrl($tempFileName);
+			$content = GeneralUtility::getUrl($tempFileName);
 			unlink($tempFileName);
 		}
 		else


### PR DESCRIPTION
… instead of escapeshellarg(). Currently, using pdfinfo, pdftotext and friends on files and directories containing non-ascii chars (eg. german umlauts) results in the non-ascii chars being removed by escapeshellarg() and the file thus not being readable (example entry from error_log: "Error: Couldn't open file 'Przisionsmessgert.pdf': No such file or directory.").

Also,
- do not escapeshellarg($tempFileName) - $tempFileName won't contain anything to escape
- make command strings more readable by using variable substitution inside double quoted strings
- import classes with long namespaces that are used more than once
- simplify getPdfInfo()
- add newline at and of file
- add 'public' access modifier to two methods
