### PR TITLE
Changed Configuration/TCA/tx_kesearch_filteroptions.php:

### DIFF
--- a/Classes/indexer/class.tx_kesearch_indexer_types.php
+++ b/Classes/indexer/class.tx_kesearch_indexer_types.php
@@ -201,7 +201,12 @@ class tx_kesearch_indexer_types {
 				$whereRow = $where;
 			}
 
-			$pageList = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->queryGen->getTreeList($row['automated_tagging'], 99, 0, $whereRow));
+			$pageList = array();
+			$automated_tagging_arr = explode(',', $row['automated_tagging']);
+			foreach ($automated_tagging_arr as $key => $value) {
+				$tmpPageList = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $this->queryGen->getTreeList($value, 99, 0, $whereRow));
+				$pageList = array_merge($tmpPageList, $pageList);
+			}
 
 			foreach($pageList as $uid) {
 				if($this->pageRecords[$uid]['tags']) {

--- a/Configuration/TCA/tx_kesearch_filteroptions.php
+++ b/Configuration/TCA/tx_kesearch_filteroptions.php
@@ -90,9 +90,9 @@ return array(
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
-                'size' => 1,
+                'size' => 5,
                 'minitems' => 0,
-                'maxitems' => 1,
+                'maxitems' => 99,
                 'wizards' => array(
                     'suggest' => array(
                         'type' => 'suggest',


### PR DESCRIPTION
Below changes were made to add a support to add tags to multiple pages and their subpages at once, not only a single one. This feature aids the usage in larger Typo3-Installments

Changed Configuration/TCA/tx_kesearch_filteroptions.php:
Adjust TCA to support multiple entry points for 'automated_tagging'

Changed Classes/indexer/class.tx_kesearch_indexer_types.php:
Adjust indexer to support the adding of tags to multiple entry points set in 'automated_tagging'

Signed-off-by: Andreas Kalkhoff a.kalkhoff@trisinus.de
