### PR TITLE
[BUGFIX] Exclude options of filters from translations

### DIFF
--- a/Configuration/TCA/tx_kesearch_filters.php
+++ b/Configuration/TCA/tx_kesearch_filters.php
@@ -102,6 +102,7 @@ return array(
         ),
         'options' => array(
             'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_filters.options',
+            'l10n_mode' => 'exclude',
             'config' => array(
                 'type' => 'inline',
                 'foreign_table' => 'tx_kesearch_filteroptions',


### PR DESCRIPTION
Filters should have the same options in all translations.
The filter options have to be translated separately.
