### PR TITLE
Add results to the options-object for fluid in case "checkFilterCondi…

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -543,6 +543,7 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 				$options[$option['uid']] = array(
 					'title' => $option['title'],
 					'value' => $option['tag'],
+					'results' => $this->tagsInSearchResult[$option['tag']],
 					'selected' =>
 							is_array($filter['selectedOptions'])
 							&& !empty($filter['selectedOptions'])


### PR DESCRIPTION
Add results to the options-object for fluid in case "checkFilterCondition" is set to "none".
This allows for numberOfResults to be displayed behind FilterOptions properly to show a user in how many FilterOptions his search phrase is found to further limit/broaden his search.

Signed-off-by: Andreas Kalkhoff a.kalkhoff@trisinus.de
