### PR TITLE
Minor changes to display results per filterOption in more cases

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -588,6 +588,9 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
                     );
                 }
             } else {
+				//fill $this->tagsInSearchResult
+				$this->filters->checkIfTagMatchesRecords($option['tag']);
+				
                 // do not process any checks; show all filter options
                 $options[$option['uid']] = array(
                     'title' => $option['title'],

--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -592,6 +592,7 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
                 $options[$option['uid']] = array(
                     'title' => $option['title'],
                     'value' => $option['tag'],
+					'results' => $this->tagsInSearchResult[$option['tag']],
                     'selected' =>
                         is_array($filter['selectedOptions'])
                         && !empty($filter['selectedOptions'])


### PR DESCRIPTION
Add tagsInSearchResult to the options-object for fluid in case if "checkFilterCondition" is "none".

This allows users to see the numberOfResults per filterOption matching his searchphrase, thus allowing them to limit/broading their search by de/selecting filteroptions.

Includes a second commit to actually fill the data required.
