### PR TITLE
Support for Fluid fallback paths

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -5,12 +5,18 @@
 # paths for fluid templating
 plugin.tx_kesearch_pi1 {
 	templateRootPath = EXT:ke_search/Resources/Private/Templates/
+	templateRootPaths.1 < .templateRootPath
 	partialRootPath = EXT:ke_search/Resources/Private/Partials/
+	partialRootPaths.1 < .partialRootPath
 	layoutRootPath = EXT:ke_search/Resources/Private/Layouts/
+	layoutRootPaths.1 < .layoutRootPath
 }
 
 plugin.tx_kesearch_pi2 {
 	templateRootPath = EXT:ke_search/Resources/Private/Templates/
+	templateRootPaths.1 < .templateRootPath
 	partialRootPath = EXT:ke_search/Resources/Private/Partials/
+	partialRootPaths.1 < .partialRootPath
 	layoutRootPath = EXT:ke_search/Resources/Private/Layouts/
+	layoutRootPaths.1 < .layoutRootPath
 }

--- a/pi1/class.tx_kesearch_pi1.php
+++ b/pi1/class.tx_kesearch_pi1.php
@@ -33,6 +33,11 @@ class tx_kesearch_pi1 extends tx_kesearch_lib
      * @var \TYPO3\CMS\Fluid\View\StandaloneView
      */
     protected $searchFormView;
+	
+	/**
+	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
+	 */
+	protected $typoScriptService;
 
     // Path to this script relative to the extension dir.
     public $scriptRelPath = 'pi1/class.tx_kesearch_pi1.php';
@@ -46,7 +51,8 @@ class tx_kesearch_pi1 extends tx_kesearch_lib
     public function main($content, $conf)
     {
         $this->ms = GeneralUtility::milliseconds();
-        $this->conf = $conf;
+        $this->typoScriptService = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');
+		$this->conf = $this->typoScriptService->convertTypoScriptArrayToPlainArray($conf);
         $this->pi_setPiVarDefaults();
         $this->pi_loadLL();
 
@@ -84,9 +90,10 @@ class tx_kesearch_pi1 extends tx_kesearch_lib
     public function initFluidTemplate()
     {
         $this->searchFormView = GeneralUtility::makeInstance('TYPO3\\CMS\\Fluid\\View\\StandaloneView');
-        $this->searchFormView->setPartialRootPaths([$this->conf['partialRootPath']]);
-        $this->searchFormView->setLayoutRootPaths([$this->conf['layoutRootPath']]);
-        $this->searchFormView->setTemplatePathAndFilename($this->conf['templateRootPath'] . 'SearchForm.html');
+        $this->searchFormView->setTemplateRootPaths($this->conf['templateRootPaths']);
+		$this->searchFormView->setPartialRootPaths($this->conf['partialRootPaths']);
+		$this->searchFormView->setLayoutRootPaths($this->conf['layoutRootPaths']);
+		$this->searchFormView->setTemplate('SearchForm');
 
         // make settings available in fluid template
         $this->searchFormView->assign('conf', $this->conf);

--- a/pi2/class.tx_kesearch_pi2.php
+++ b/pi2/class.tx_kesearch_pi2.php
@@ -34,6 +34,11 @@ class tx_kesearch_pi2 extends tx_kesearch_lib
      * @var \TYPO3\CMS\Fluid\View\StandaloneView
      */
     protected $resultListView;
+	
+	/**
+	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
+	 */
+	protected $typoScriptService;
 
     // Path to this script relative to the extension dir.
     public $scriptRelPath = 'pi2/class.tx_kesearch_pi2.php';
@@ -47,7 +52,8 @@ class tx_kesearch_pi2 extends tx_kesearch_lib
     public function main($content, $conf)
     {
         $this->ms = GeneralUtility::milliseconds();
-        $this->conf = $conf;
+        $this->typoScriptService = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');
+		$this->conf = $this->typoScriptService->convertTypoScriptArrayToPlainArray($conf);
         $this->pi_setPiVarDefaults();
 
         // use pi1 locallang values, since all the frontend locallang values for
@@ -122,9 +128,10 @@ class tx_kesearch_pi2 extends tx_kesearch_lib
     public function initFluidTemplate()
     {
         $this->resultListView = GeneralUtility::makeInstance('TYPO3\\CMS\\Fluid\\View\\StandaloneView');
-        $this->resultListView->setPartialRootPaths([$this->conf['partialRootPath']]);
-        $this->resultListView->setLayoutRootPaths([$this->conf['layoutRootPath']]);
-        $this->resultListView->setTemplatePathAndFilename($this->conf['templateRootPath'] . 'ResultList.html');
+        $this->resultListView->setTemplateRootPaths($this->conf['templateRootPaths']);
+		$this->resultListView->setPartialRootPaths($this->conf['partialRootPaths']);
+		$this->resultListView->setLayoutRootPaths($this->conf['layoutRootPaths']);
+		$this->resultListView->setTemplate('ResultList');
 
         // make settings available in fluid template
         $this->resultListView->assign('conf', $this->conf);


### PR DESCRIPTION
See issue https://github.com/teaminmedias-pluswerk/ke_search/issues/18 .. with a little typoscript twist this change is fully backwards compatible.

You now can define your templates just like:
```
plugin.tx_kesearch_pi1 {
  templateRootPaths {
    10 = ...
...
```