### PR TITLE
[BUGFIX] Make backend module accessible for non-admin users

### DIFF
--- a/Classes/Controller/BackendModuleController.php
+++ b/Classes/Controller/BackendModuleController.php
@@ -76,7 +76,7 @@ class BackendModuleController extends AbstractBackendModuleController
 
         $this->do = GeneralUtility::_GET('do');
 
-        $this->perms_clause = $this->getBackendUser()->getPagePermsClause($this->id);
+        $this->perms_clause = $this->getBackendUser()->getPagePermsClause(1);
         $this->pageinfo = BackendUtility::readPageAccess($this->id, $this->perms_clause);
 
         // check access and redirect accordingly


### PR DESCRIPTION
Before this patch just page with uid=1 was accessible for non-admin
users. Problem was a wrong parameter in getPagePermsClause() method.

Resolves: #89