### PR TITLE
[BUGFIX] Make file indexing (from RTE) work with new typolink syntax

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ChangeLog
 
 current master
+[BUGFIX]  Make file indexing (from RTE) work with new typolink syntax
 [BUGFIX]  Register wizard icon in IconRegistry
 [BUGFIX]  Add switch for core locallang files
 [TASK]    Remove include of old and outdated tt_news libs

--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -729,31 +729,50 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
         /* @var $rteHtmlParser \TYPO3\CMS\Core\Html\RteHtmlParser */
         $rteHtmlParser = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Html\\RteHtmlParser');
 
-        $blockSplit = $rteHtmlParser->splitIntoBlock('link', $ttContentRow['bodytext'], 1);
-        foreach ($blockSplit as $k => $v) {
-            if ($k % 2) {
-                $tagCode = GeneralUtility::unQuoteFilenames(
-                    trim(substr($rteHtmlParser->getFirstTag($v), 0, -1)),
-                    true
-                );
-                $link_param = $tagCode[1];
+        if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) <
+            \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('8.0')
+        ) {
+            // TYPO3 7.6
+            $blockSplit = $rteHtmlParser->splitIntoBlock('link', $ttContentRow['bodytext'], 1);
+            foreach ($blockSplit as $k => $v) {
+                if ($k % 2) {
+                    $tagCode = GeneralUtility::unQuoteFilenames(
+                        trim(substr($rteHtmlParser->getFirstTag($v), 0, -1)),
+                        true
+                    );
+                    $link_param = $tagCode[1];
 
-                // Check for FAL link-handler keyword
-                list($linkHandlerKeyword, $linkHandlerValue) = explode(':', trim($link_param), 2);
-                if ($linkHandlerKeyword === 'file') {
-                    try {
-                        $fileOrFolderObject = ResourceFactory::getInstance()->retrieveFileOrFolderObject(
-                            rawurldecode($linkHandlerValue)
-                        );
-                        if ($fileOrFolderObject instanceof FileInterface) {
-                            $fileObjects[] = $fileOrFolderObject;
+                    // Check for FAL link-handler keyword
+                    list($linkHandlerKeyword, $linkHandlerValue) = explode(':', trim($link_param), 2);
+                    if ($linkHandlerKeyword === 'file') {
+                        try {
+                            $fileOrFolderObject = ResourceFactory::getInstance()->retrieveFileOrFolderObject(
+                                rawurldecode($linkHandlerValue)
+                            );
+                            if ($fileOrFolderObject instanceof FileInterface) {
+                                $fileObjects[] = $fileOrFolderObject;
+                            }
+                        } catch (ResourceDoesNotExistException $resourceDoesNotExistException) {
+                            $this->addError(
+                                'Could not index file with FAL uid #'
+                                . $linkHandlerValue
+                                . ' (the indentifier inserted in the RTE is already gone).'
+                            );
                         }
-                    } catch (ResourceDoesNotExistException $resourceDoesNotExistException) {
-                        $this->addError(
-                            'Could not index file with FAL uid #'
-                            . $linkHandlerValue
-                            . ' (the indentifier inserted in the RTE is already gone).'
-                        );
+                    }
+                }
+            }
+        } else {
+            // TYPO3 8.7
+            /** @var \TYPO3\CMS\Core\LinkHandling\LinkService $linkService */
+            $linkService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\LinkHandling\LinkService::class);
+            $blockSplit = $rteHtmlParser->splitIntoBlock('A', $ttContentRow['bodytext'], 1);
+            foreach ($blockSplit as $k => $v) {
+                list($attributes) = $rteHtmlParser->get_tag_attributes($rteHtmlParser->getFirstTag($v), true);
+                if (!empty($attributes['href'])) {
+                    $hrefInformation = $linkService->resolve($attributes['href']);
+                    if ($hrefInformation['type'] === \TYPO3\CMS\Core\LinkHandling\LinkService::TYPE_FILE) {
+                        $fileObjects[] = $hrefInformation['file'];
                     }
                 }
             }


### PR DESCRIPTION
In TYPO3 8 the new LinkService has been introduced, to resolve typolinks
with new syntax (t3://). ke_search indexer checks TYPO3 version and
uses the old way in TYPO3 7.6 or the new LinkService in TYPO3 8.7.

Resolves: #98