### PR TITLE
[BUGFIX] Respect visibility of immediate parent gridelements container

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ChangeLog
 
 current master
+[BUGFIX]  Respect visibility of immediate parent gridelements container when indexing content elements
 [BUGFIX]  Register wizard icon in IconRegistry
 [BUGFIX]  Add switch for core locallang files
 [TASK]    Remove include of old and outdated tt_news libs

--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -397,6 +397,8 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
         // add condition for not indexing gridelement columns with colPos = -2 (= invalid)
         if (ExtensionManagementUtility::isLoaded('gridelements')) {
             $where .= ' AND colPos <> -2 ';
+            $fields .= ', (SELECT hidden FROM tt_content as t2 WHERE t2.uid = tt_content.tx_gridelements_container)' .
+                       ' as parentGridHidden';
         }
 
         $where .= BackendUtility::BEenableFields($table);
@@ -422,6 +424,11 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
         $pageContent = array();
         if (count($ttContentRows)) {
             foreach ($ttContentRows as $ttContentRow) {
+                if (ExtensionManagementUtility::isLoaded('gridelements') && $ttContentRow['parentGridHidden'] === '1') {
+                    // If parent grid element is hidden, don't index this content element
+                    continue;
+                }
+
                 $content = '';
 
                 // index header


### PR DESCRIPTION
When content elements are located within a disabled gridelements
container, they were not visible in frontend but ke_search still
indexed them.

Now, content elements located in a grid which is disabled are ignored
from indexer. This just works for direct children of gridelements,
because this fix works not recursively.

Resolves: #104