### PR TITLE
[TASK] Update issues url and fix license property in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,7 @@
   "type": "typo3-cms-extension",
   "description": "Search Extension for TYPO3, including faceting search functions.",
   "homepage": "https://www.typo3-macher.de/en/facetted-search-ke-search/",
-  "license": [
-    "GPL-2.0+"
-  ],
+  "license": "GPL-2.0+",
   "keywords": [
     "TYPO3 CMS",
     "search",
@@ -15,10 +13,9 @@
     "faceted search"
   ],
   "support": {
-    "issues": "https://forge.typo3.org/projects/extension-ke_search/issues"
+    "issues": "https://github.com/teaminmedias-pluswerk/ke_search/issues"
   },
   "require": {
-    "php": ">=5.5.0",
     "typo3/cms-core": "^7.6 || ^8.7"
   },
   "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,7 +23,6 @@ $EM_CONF[$_EXTKEY] = array(
     'CGLcompliance_note' => '',
     'constraints' => array(
         'depends' => array(
-            'php' => '5.5.0-7.1.99',
             'typo3' => '7.6.0-8.7.99',
         ),
         'conflicts' => array(),


### PR DESCRIPTION
URL to issue tracker updated.

License attribute in composer.json expects to be a string, not an
array (it's not named "licenses").

Also removed php dependency in composer.json and ext_emconf.php.
Minimum supported TYPO3 version (7.6) already requires PHP 5.5. So we
don't need to define it twice.