### PR TITLE
[BUGFIX] Support several pages when loading filters and options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ChangeLog
 
 current master
+[BUGFIX]  Support several pages when loading filters and options
 [BUGFIX]  Register wizard icon in IconRegistry
 [BUGFIX]  Add switch for core locallang files
 [TASK]    Remove include of old and outdated tt_news libs

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,10 +11,6 @@ if (TYPO3_MODE == 'BE') {
     );
 }
 
-// include filterlist class and pageTSconfig.txt and add plugin
-include_once(TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY)
-    . '/Classes/Backend/class.user_filterlist.php');
-
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
     '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:ke_search/pageTSconfig.txt">'
 );


### PR DESCRIPTION
Also added support for TYPO3 7.6 and 8.7, which use different
types for values in "pages" attribute (in plugin).

Resolves: #113