### PR TITLE
Escape all PCRE characters when highlighting searchwords

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ChangeLog
 
 current master
+[BUGFIX]  Escape all PCRE characters when highlighting searchwords
 [BUGFIX]  Allow multple preselected filter options, https://github.com/teaminmedias-pluswerk/ke_search/issues/116.
 
 Version 2.5.0, May 2017

--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -220,7 +220,7 @@ class tx_kesearch_lib_searchresult
                 '<span class="hit">\0</span>';
 
             foreach ($wordArray as $word) {
-                $word = str_replace('/', '\/', $word);
+                $word = preg_replace('/([?#^&*()$\\/])/', '\\\\$1', $word);
                 $word = htmlspecialchars($word);
                 $content = preg_replace('/(' . $word . ')/iu', $highlightedWord, $content);
             }

--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -220,7 +220,7 @@ class tx_kesearch_lib_searchresult
                 '<span class="hit">\0</span>';
 
             foreach ($wordArray as $word) {
-                $word = preg_replace('/([?#^&*()$\\/])/', '\\\\$1', $word);
+                $word = preg_replace('/([\W])/', '\\\\$1', $word);
                 $word = htmlspecialchars($word);
                 $content = preg_replace('/(' . $word . ')/iu', $highlightedWord, $content);
             }


### PR DESCRIPTION
The highlight function doesn't escape all possible regular expression chars so it actually crashes if you have brackets in your searchword and highlighting activated.

Error was:

> #1: PHP Warning: preg_replace(): Compilation failed: missing ) at offset 6 in typo3conf/ext/ke_search/Classes/lib/class.tx_kesearch_lib_searchresult.php line 226

I'm not 100% sure if this regexp is enough, but I could not reproduce any errors with this.