### PR TITLE
[FEATURE] - add template layout chooser

### DIFF
--- a/pi1/flexform_pi1.xml
+++ b/pi1/flexform_pi1.xml
@@ -173,6 +173,22 @@
 				<type>array</type>
 				<el>
 
+					<templateLayout>
+						<TCEforms>
+							<label>LLL:EXT:ke_search/pi1/locallang.xml:ff.templateLayout</label>
+							<config>
+								<type>select</type>
+								<items>
+									<numIndex index="0">
+										<numIndex index="0">LLL:EXT:ke_search/pi1/locallang.xml:ff.templateLayout.I.0</numIndex>
+										<numIndex index="1">10</numIndex>
+									</numIndex>
+								</items>
+								<size>1</size>
+							</config>
+						</TCEforms>
+					</templateLayout>
+
 					<highlightSword>
 						<TCEforms>
 							<label>LLL:EXT:ke_search/pi1/locallang.xml:ff.highlightSword</label>

--- a/pi1/locallang.xml
+++ b/pi1/locallang.xml
@@ -38,6 +38,8 @@
 			<label index="ff.resultLinkTarget.I.0">Open in new window</label>
 			<label index="ff.resultLinkTarget.I.1">Open in same window</label>
 			<label index="ff.resultsNumeration">Number results consecutively?</label>
+			<label index="ff.templateLayout">Template Layout</label>
+			<label index="ff.templateLayout.I.0">Default</label>
 			<label index="ff.highlightSword">Highlight search word in result preview</label>
 			<label index="ff.previewMode">Text for used for search result (preview text)</label>
 			<label index="ff.previewMode.I.0">Always show the abstract if set.</label>


### PR DESCRIPTION
Usage:

Add your custom template layout select items within the plugin settings:

        TCEFORM {
            tt_content {
                pi_flexform.ke_search_pi1.view.templateLayout.addItems {
                    20 = Custom search box 1
                }
            }
        }

Register your own template paths:

        plugin.tx_kesearch_pi1 {
            templateRootPaths {
                5 = EXT:your_site_package/Resources/Private/Templates/KeSearch/
            }
            partialRootPaths {
                5 = EXT:your_site_package/Resources/Private/Partials/KeSearch/
            }
        }

EXT:your_site_package/Resources/Private/Templates/KeSearch/SearchForm.html:

        <f:layout name="General"/>
        <f:section name="content">
            <f:if condition="{conf.templateLayout}">
                <f:if condition="{conf.templateLayout} == 10">
                    <f:render section="defaultLayout" arguments="{_all}"/>
                </f:if>
                <f:if condition="{conf.templateLayout} == 20">
                    <f:render section="customLayout" arguments="{_all}"/>
                </f:if>
            </f:if>
        </f:section>

        <f:section name="defaultLayout">
            ... default template code
        </f:section>

        <f:section name="customLayout">
            ... custom template code
        </f:section>
