### PR TITLE
Fixes #124 - Translation of Filter Options does not work

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ChangeLog
 
 current master
+[BUGFIX]  Fix translation of filter options
 [BUGFIX]  Allow multple preselected filter options, https://github.com/teaminmedias-pluswerk/ke_search/issues/116.
 
 Version 2.5.0, May 2017

--- a/Classes/lib/class.tx_kesearch_filters.php
+++ b/Classes/lib/class.tx_kesearch_filters.php
@@ -271,7 +271,15 @@ class tx_kesearch_filters
                         $GLOBALS['TSFE']->sys_language_content,
                         $GLOBALS['TSFE']->sys_language_contentOL
                     );
-                    $rows[$key] = $row;
+
+                    if( is_array($row)) {
+                        if( $table == "tx_kesearch_filters") {
+                            $row['rendertype'] = $rows[$key]['rendertype'] ;
+                        }
+                        $rows[$key] = $row;
+                    } else {
+                        unset( $rows[$key] ) ;
+                    }
                 }
             }
             return $rows;

--- a/Classes/lib/class.tx_kesearch_filters.php
+++ b/Classes/lib/class.tx_kesearch_filters.php
@@ -262,6 +262,11 @@ class tx_kesearch_filters
      */
     public function languageOverlay(array $rows, $table)
     {
+        // see https://github.com/teaminmedias-pluswerk/ke_search/issues/128
+        $LanguageMode = $GLOBALS['TSFE']->sys_language_content ;
+        if( \TYPO3\CMS\Core\Utility\GeneralUtility::hideIfNotTranslated( $GLOBALS['TSFE']->page['l18n_cfg'] )) {
+            $LanguageMode = 'hideNonTranslated' ;
+        }
         if (is_array($rows) && count($rows)) {
             foreach ($rows as $key => $row) {
                 if (is_array($row) && $GLOBALS['TSFE']->sys_language_content) {
@@ -269,7 +274,7 @@ class tx_kesearch_filters
                         $table,
                         $row,
                         $GLOBALS['TSFE']->sys_language_content,
-                        $GLOBALS['TSFE']->sys_language_contentOL
+                        $LanguageMode
                     );
 
                     if( is_array($row)) {

--- a/Classes/lib/class.tx_kesearch_filters.php
+++ b/Classes/lib/class.tx_kesearch_filters.php
@@ -264,7 +264,7 @@ class tx_kesearch_filters
     {
         if (is_array($rows) && count($rows)) {
             foreach ($rows as $key => $row) {
-                if (is_array($row) && $GLOBALS['TSFE']->sys_language_contentOL) {
+                if (is_array($row) && $GLOBALS['TSFE']->sys_language_content) {
                     $row = $GLOBALS['TSFE']->sys_page->getRecordOverlay(
                         $table,
                         $row,

--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -780,8 +780,8 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
         $this->searchResult = GeneralUtility::makeInstance('tx_kesearch_lib_searchresult', $this);
 
         $this->fluidTemplateVariables['resultrows'] = array();
-
-        foreach ($rows as $row) {
+        if( is_array($rows) ) {
+            foreach ($rows as $row) {
             $this->searchResult->setRow($row);
 
             $tempMarkerArray = array(
@@ -851,6 +851,7 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
 
             // increase result counter
             $resultCount++;
+        }
         }
     }
 

--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -782,76 +782,76 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
         $this->fluidTemplateVariables['resultrows'] = array();
         if( is_array($rows) ) {
             foreach ($rows as $row) {
-            $this->searchResult->setRow($row);
+                $this->searchResult->setRow($row);
 
-            $tempMarkerArray = array(
-                'orig_uid' => $row['orig_uid'],
-                'orig_pid' => $row['orig_pid'],
-                'title' => $this->searchResult->getTitle(),
-                'teaser' => $this->searchResult->getTeaser(),
-            );
+                $tempMarkerArray = array(
+                    'orig_uid' => $row['orig_uid'],
+                    'orig_pid' => $row['orig_pid'],
+                    'title' => $this->searchResult->getTitle(),
+                    'teaser' => $this->searchResult->getTeaser(),
+                );
 
-            // hook for additional markers in result row
-            if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['additionalResultMarker'])) {
-                // make curent row number available to hook
-                $this->currentRowNumber = $resultCount;
-                foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['additionalResultMarker'] as $_classRef) {
-                    $_procObj = &GeneralUtility::getUserObj($_classRef);
-                    $_procObj->additionalResultMarker($tempMarkerArray, $row, $this);
+                // hook for additional markers in result row
+                if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['additionalResultMarker'])) {
+                    // make curent row number available to hook
+                    $this->currentRowNumber = $resultCount;
+                    foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['additionalResultMarker'] as $_classRef) {
+                        $_procObj = &GeneralUtility::getUserObj($_classRef);
+                        $_procObj->additionalResultMarker($tempMarkerArray, $row, $this);
+                    }
+                    unset($this->currentRowNumber);
                 }
-                unset($this->currentRowNumber);
+
+                // add type marker
+                // for file results just use the "file" type, not the file extension (eg. "file:pdf")
+                list($type) = explode(':', $row['type']);
+                $tempMarkerArray['type'] = str_replace(' ', '_', $type);
+
+                // use the markers array as a base for the fluid template values
+                $resultrowTemplateValues = $tempMarkerArray;
+
+                // set result url
+                $resultUrl = $this->searchResult->getResultUrl($this->conf['renderResultUrlAsLink']);
+                $resultrowTemplateValues['url'] = $resultUrl;
+
+                // set result numeration
+                $resultNumber = $resultCount
+                    + ($this->piVars['page'] * $this->conf['resultsPerPage'])
+                    - $this->conf['resultsPerPage'];
+                $resultrowTemplateValues['number'] = $resultNumber;
+
+                // set score (used for plain score output and score scale)
+                $resultScore = number_format($row['score'], 2, ',', '');
+                $resultrowTemplateValues['score'] = $resultScore;
+
+                // set date (formatted and raw as a timestamp)
+                $resultDate = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], $row['sortdate']);
+                $resultrowTemplateValues['date'] = $resultDate;
+                $resultrowTemplateValues['date_timestamp'] = $row['sortdate'];
+
+                // set percental score
+                $resultrowTemplateValues['percent'] = $row['percent'];
+
+                // show tags?
+                $tags = $row['tags'];
+                $tags = str_replace('#', ' ', $tags);
+                $resultrowTemplateValues['tags'] = $tags;
+
+                // set preview image
+                $renderedImage = $this->renderPreviewImageOrTypeIcon($row);
+                $resultrowTemplateValues['imageHtml'] = $renderedImage;
+
+                // set end date for cal events
+                if ($type == 'cal') {
+                    $resultrowTemplateValues['cal'] = $this->getCalEventEnddate($row['orig_uid']);
+                }
+
+                // add result row to the variables array
+                $this->fluidTemplateVariables['resultrows'][] = $resultrowTemplateValues;
+
+                // increase result counter
+                $resultCount++;
             }
-
-            // add type marker
-            // for file results just use the "file" type, not the file extension (eg. "file:pdf")
-            list($type) = explode(':', $row['type']);
-            $tempMarkerArray['type'] = str_replace(' ', '_', $type);
-
-            // use the markers array as a base for the fluid template values
-            $resultrowTemplateValues = $tempMarkerArray;
-
-            // set result url
-            $resultUrl = $this->searchResult->getResultUrl($this->conf['renderResultUrlAsLink']);
-            $resultrowTemplateValues['url'] = $resultUrl;
-
-            // set result numeration
-            $resultNumber = $resultCount
-                + ($this->piVars['page'] * $this->conf['resultsPerPage'])
-                - $this->conf['resultsPerPage'];
-            $resultrowTemplateValues['number'] = $resultNumber;
-
-            // set score (used for plain score output and score scale)
-            $resultScore = number_format($row['score'], 2, ',', '');
-            $resultrowTemplateValues['score'] = $resultScore;
-
-            // set date (formatted and raw as a timestamp)
-            $resultDate = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], $row['sortdate']);
-            $resultrowTemplateValues['date'] = $resultDate;
-            $resultrowTemplateValues['date_timestamp'] = $row['sortdate'];
-
-            // set percental score
-            $resultrowTemplateValues['percent'] = $row['percent'];
-
-            // show tags?
-            $tags = $row['tags'];
-            $tags = str_replace('#', ' ', $tags);
-            $resultrowTemplateValues['tags'] = $tags;
-
-            // set preview image
-            $renderedImage = $this->renderPreviewImageOrTypeIcon($row);
-            $resultrowTemplateValues['imageHtml'] = $renderedImage;
-
-            // set end date for cal events
-            if ($type == 'cal') {
-                $resultrowTemplateValues['cal'] = $this->getCalEventEnddate($row['orig_uid']);
-            }
-
-            // add result row to the variables array
-            $this->fluidTemplateVariables['resultrows'][] = $resultrowTemplateValues;
-
-            // increase result counter
-            $resultCount++;
-        }
         }
     }
 

--- a/Configuration/TCA/tx_kesearch_filters.php
+++ b/Configuration/TCA/tx_kesearch_filters.php
@@ -82,7 +82,6 @@ return array(
         ),
         'rendertype' => array(
             'exclude' => 0,
-            /* 'l10n_mode' => 'exclude',  // with this option you cannot create a filter in just one language */
             'l10n_display' => 'defaultAsReadonly',
             'displayCond' => 'FIELD:l10n_parent:<:1',
             'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_filters.rendertype',

--- a/Configuration/TCA/tx_kesearch_filters.php
+++ b/Configuration/TCA/tx_kesearch_filters.php
@@ -82,7 +82,9 @@ return array(
         ),
         'rendertype' => array(
             'exclude' => 0,
-            'l10n_mode' => 'exclude',
+            /* 'l10n_mode' => 'exclude',  // with this option you cannot create a filter in just one language */
+            'l10n_display' => 'defaultAsReadonly',
+            'displayCond' => 'FIELD:l10n_parent:<:1',
             'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_filters.rendertype',
             'config' => array(
                 'type' => 'select',


### PR DESCRIPTION
See Issue #124 

Just check if we are in a translated Version of the Website or if sys_language_content has fallback to default language instead of the used language mode by removing the "OL" in if condition $GLOBALS['TSFE']->sys_language_contentOL )