### PR TITLE
[BUGFIX] Replace GeneralUtility::inArray() with in_array

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ChangeLog
 
 current master
+[TASK]    Remove deprecated occurrences of ArrayUtility:inArray()
 [BUGFIX]  Allow multple preselected filter options, https://github.com/teaminmedias-pluswerk/ke_search/issues/116.
 
 Version 2.5.0, May 2017

--- a/Classes/lib/class.tx_kesearch_filters.php
+++ b/Classes/lib/class.tx_kesearch_filters.php
@@ -17,7 +17,6 @@
  ***************************************************************/
 
 use \TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\ArrayUtility;
 
 /**
  * Plugin 'Faceted search - searchbox and filters' for the 'ke_search' extension.

--- a/Classes/lib/class.tx_kesearch_filters.php
+++ b/Classes/lib/class.tx_kesearch_filters.php
@@ -117,7 +117,7 @@ class tx_kesearch_filters
                     // add preselected filter to piVars
                     $this->pObj->piVars['filter'][$filter['uid']][$option['uid']] = $option['tag'];
                 } else { // else test all other filter
-                    $isInArray = ArrayUtility::inArray($this->pObj->piVars['filter'][$filter['uid']], $option['tag']);
+                    $isInArray = in_array($this->pObj->piVars['filter'][$filter['uid']], $option['tag']);
                     if ($isInArray) {
                         $selected = true;
                     }

--- a/Classes/lib/class.tx_kesearch_lib_sorting.php
+++ b/Classes/lib/class.tx_kesearch_lib_sorting.php
@@ -193,7 +193,7 @@ class tx_kesearch_lib_sorting
     {
         $allowedDirections = array('asc', 'desc');
         $direction = strtolower($direction);
-        $isInArray = TYPO3\CMS\Core\Utility\GeneralUtility::inArray($allowedDirections, $direction);
+        $isInArray = in_array($allowedDirections, $direction, true);
         if (!empty($direction) && $isInArray) {
             if ($direction == 'asc') {
                 $direction = 'desc';


### PR DESCRIPTION
Because of deprecation of ArrayUtility:inArray: https://docs.typo3.org/typo3cms/extensions/core/8.7/Changelog/8.6/Deprecation-79316-DeprecateArrayUtilityinArray.html
and the issue https://github.com/teaminmedias-pluswerk/ke_search/issues/136