### PR TITLE
Avoid duplicate text in search result teaser

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -245,38 +245,55 @@ class tx_kesearch_lib_searchresult
             $charsBeforeAfterSearchWord = ceil($charsForEachSearchWord / 2);
             $aSearchWordWasFound = false;
             $isSearchWordAtTheBeginning = false;
+            $teaserArray = [];
             foreach ($this->pObj->swords as $word) {
-                $word = ' ' . $word; // our searchengine searches for wordbeginnings
-                $pos = stripos($content, $word);
-                if ($pos === false) {
-                    // if the word was not found it could be within brakets => (searchWord)
-                    // so give it a second try
-                    $pos = stripos($content, trim($word));
-                    if ($pos === false) {
-                        continue;
+                // Always remove whitespace around searchword first
+                $word = trim($word);
+
+                // Check teaser text array first to avoid duplicate text parts
+                if (count($teaserArray) > 0) {
+                    foreach ($teaserArray as $teaserArrayItem) {
+                        $searchWordPositionInTeaserArray = stripos($teaserArrayItem, $word);
+                        if (false === $searchWordPositionInTeaserArray) {
+                            continue;
+                        } else {
+                            // One finding in teaser text array is sufficient
+                            $aSearchWordWasFound = true;
+                            break;
+                        }
                     }
                 }
-                $aSearchWordWasFound = true;
 
-                // if searchword is the first word
-                if ($pos === 0) {
-                    $isSearchWordAtTheBeginning = true;
+                // Only search for current search word in content if it wasn't found in teaser text array already
+                if (false === $aSearchWordWasFound) {
+                    $pos = stripos($content, $word);
+                    if (false === $pos) {
+                        continue;
+                    }
+                    $aSearchWordWasFound = true;
+
+                    // if search word is the first word
+                    if (0 === $pos) {
+                        $isSearchWordAtTheBeginning = true;
+                    }
+
+                    // find search starting point
+                    $startPos = $pos - $charsBeforeAfterSearchWord;
+                    if ($startPos < 0) {
+                        $startPos = 0;
+                    }
+
+                    // crop some words behind search word
+                    $partWithSearchWord = substr($content, $startPos);
+                    $temp = $this->cObj->crop($partWithSearchWord, $charsForEachSearchWord . '|...|1');
+
+                    // crop some words before search word
+                    // after last cropping our text is too short now. So we have to find a new cutting position
+                    ($startPos > 10) ? $length = strlen($temp) - 10 : $length = strlen($temp);
+
+                    // Store content part containing the search word in teaser text array
+                    $teaserArray[] = $this->cObj->crop($temp, '-' . $length . '||1');
                 }
-
-                // find search starting point
-                $startPos = $pos - $charsBeforeAfterSearchWord;
-                if ($startPos < 0) {
-                    $startPos = 0;
-                }
-
-                // crop some words behind searchword
-                $partWithSearchWord = substr($content, $startPos);
-                $temp = $this->cObj->crop($partWithSearchWord, $charsForEachSearchWord . '|...|1');
-
-                // crop some words before searchword
-                // after last cropping our text is too short now. So we have to find a new cutting position
-                ($startPos > 10) ? $length = strlen($temp) - 10 : $length = strlen($temp);
-                $teaserArray[] = $this->cObj->crop($temp, '-' . $length . '||1');
             }
 
             // When the searchword was found in title but not in content the teaser is empty


### PR DESCRIPTION
When the searchword consists of two words and both happen to be very close to each other in the document, then the results duplicates the matched text.

Eg. document contains "lorem ipsum", user searches for "lorem ipsum", result will show "lorem ipsum lorem ipsum".

Store each match in an array to avoid duplicating short text strings within the result teaser.