### PR TITLE
[BUGFIX] load TypoScriptService correctly depending on the TYPO3 version

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -18,7 +18,6 @@
  ***************************************************************/
 
 use \TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use \TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use \TYPO3\CMS\Core\Utility\HttpUtility;
 
@@ -134,7 +133,13 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
     {
         // get some helper functions
         $this->div = GeneralUtility::makeInstance('tx_kesearch_lib_div', $this);
-        $this->typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
+
+        if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8007000) {
+            $this->typoScriptService = GeneralUtility::makeInstance(TYPO3\CMS\Core\TypoScript\TypoScriptService::class);
+        }
+        else {
+            $this->typoScriptService = GeneralUtility::makeInstance(TYPO3\CMS\Extbase\Service\TypoScriptService::class);
+        }
 
         // set start of query timer
         if (!$GLOBALS['TSFE']->register['ke_search_queryStartTime']) {

--- a/pi1/class.tx_kesearch_pi1.php
+++ b/pi1/class.tx_kesearch_pi1.php
@@ -46,7 +46,14 @@ class tx_kesearch_pi1 extends tx_kesearch_lib
     public function main($content, $conf)
     {
         $this->ms = GeneralUtility::milliseconds();
-        $typoScriptService = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');
+
+        if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8007000) {
+            $typoScriptService = GeneralUtility::makeInstance(TYPO3\CMS\Core\TypoScript\TypoScriptService::class);
+        }
+        else {
+            $typoScriptService = GeneralUtility::makeInstance(TYPO3\CMS\Extbase\Service\TypoScriptService::class);
+        }
+
         $this->conf = $typoScriptService->convertTypoScriptArrayToPlainArray($conf);
         $this->pi_setPiVarDefaults();
         $this->pi_loadLL();

--- a/pi2/class.tx_kesearch_pi2.php
+++ b/pi2/class.tx_kesearch_pi2.php
@@ -47,7 +47,14 @@ class tx_kesearch_pi2 extends tx_kesearch_lib
     public function main($content, $conf)
     {
         $this->ms = GeneralUtility::milliseconds();
-        $typoScriptService = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');
+
+        if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8007000) {
+            $typoScriptService = GeneralUtility::makeInstance(TYPO3\CMS\Core\TypoScript\TypoScriptService::class);
+        }
+        else {
+            $typoScriptService = GeneralUtility::makeInstance(TYPO3\CMS\Extbase\Service\TypoScriptService::class);
+        }
+
         $this->conf = $typoScriptService->convertTypoScriptArrayToPlainArray($conf);
         $this->pi_setPiVarDefaults();
 


### PR DESCRIPTION
Loads TypoScriptService depending on TYPO3 Version number.

Also fixes the used namespace for tx_kesearch_pi1 and tx_kesearch_pi2 since both still used the namespace that is only valid for TYPO3 7.6.

Resolves #161 