### PR TITLE
Improve permission handling, allow multiple file indexes

### DIFF
--- a/Classes/indexer/class.tx_kesearch_indexer.php
+++ b/Classes/indexer/class.tx_kesearch_indexer.php
@@ -506,7 +506,8 @@ class tx_kesearch_indexer
         if (substr($type, 0, 4) == 'file') {
             $recordExists = $this->checkIfFileWasIndexed(
                 $fieldValues['type'],
-                $fieldValues['hash']
+                $fieldValues['hash'],
+                $fieldValues['pid']
             );
         } else {
             $recordExists = $this->checkIfRecordWasIndexed(
@@ -705,11 +706,11 @@ class tx_kesearch_indexer
      * @param integer $hash
      * @return boolean true if record was found, false if not
      */
-    public function checkIfFileWasIndexed($type, $hash)
+    public function checkIfFileWasIndexed($type, $hash, $pid)
     {
         // Query DB if record already exists
         $res = $GLOBALS['TYPO3_DB']->sql_query(
-            'SELECT * FROM tx_kesearch_index WHERE ' . 'type = ' . $type . ' AND hash = ' . $hash . ' LIMIT 1'
+            'SELECT * FROM tx_kesearch_index WHERE ' . 'type = ' . $type . ' AND hash = ' . $hash . ' AND pid = ' . (int) $pid . ' LIMIT 1'
         );
         if ($GLOBALS['TYPO3_DB']->sql_num_rows($res)) {
             if ($this->currentRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {

--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_file.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_file.php
@@ -339,6 +339,10 @@ class tx_kesearch_indexer_types_file extends tx_kesearch_indexer_types
             // index meta data from FAL: title, description, alternative
             $additionalContent = '';
 
+            if ($metadata['fe_groups']) {
+                $indexRecordValues['fe_group'] = $metadata['fe_groups'];
+            }
+
             if ($metadata['title']) {
                 $additionalContent = $metadata['title'] . "\n" ;
             }

--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -806,6 +806,16 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
             $metadata = $fileObject->_getMetaData();
         }
 
+        if ($metadata['fe_groups']) {
+            if ($feGroups) {
+                $feGroupsContentArray = GeneralUtility::intExplode(',', $feGroups);
+                $feGroupsFileArray = GeneralUtility::intExplode(',', $metadata['fe_groups']);
+                $feGroups = implode(',', array_intersect($feGroupsContentArray, $feGroupsFileArray));
+            } else {
+                $feGroups = $metadata['fe_groups'];
+            }
+        }
+
         // assign categories as tags (as cleartext, eg. "colorblue")
         $categories = tx_kesearch_helper::getCategories($metadata['uid'], 'sys_file_metadata');
         tx_kesearch_helper::makeTags($tags, $categories['title_list']);

--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -615,7 +615,7 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
                 $feGroupsContentElement
             );
             $feGroupsPagesArray = GeneralUtility::intExplode(',', $feGroupsPages);
-            $feGroups = implode(',', array_intersect($feGroupsContentElementArray, $feGroupsContentElementArray));
+            $feGroups = implode(',', array_intersect($feGroupsContentElementArray, $feGroupsPagesArray));
         }
 
         if (($feGroupsContentElement


### PR DESCRIPTION
From my point of view, permissions aren't always checked correctly for search results. Also, it would be nice to be able to index files multiple times because they could vary in their metadata (e. g. permissions, relations to other records, overwritten title/alt).