### PR TITLE
check if $searchParts[$key] contains quotation marks before

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib_searchphrase.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchphrase.php
@@ -127,7 +127,7 @@ class tx_kesearch_lib_searchphrase
             foreach ($searchParts as $key => $word) {
                 if ($word != '|') {
                     // enable part searching by default. But be careful: Enabling this slows down the search engine
-                    if (!isset($this->pObj->extConf['enablePartSearch']) || $this->pObj->extConf['enablePartSearch']) {
+                    if (!preg_match('/^(\+|\-|\~|<|>)?\"/', $searchParts[$key]) && (!isset($this->pObj->extConf['enablePartSearch']) || $this->pObj->extConf['enablePartSearch'])) {
                         if ($this->pObj->extConfPremium['enableInWordSearch']) {
                             $searchParts[$key] = '*' . trim($searchParts[$key], '*') . '*';
                         } else {


### PR DESCRIPTION
If enabled "In word search" is combined with a search phrase in quotation marks it results in MySQL Error: 
"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '*' at line 1"