### PR TITLE
Feature/search fields for pages

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -284,7 +284,7 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
                     'pages_language_overlay',
                     'pid',
                     $pageRow['uid'],
-                    'AND sys_language_uid=' . (int) $sysLang['uid']
+                    'AND sys_language_uid=' . (int)$sysLang['uid']
                 );
                 if ($pageOverlay) {
                     $this->cachedPageRecords[$sysLang['uid']][$pageRow['uid']] = $pageOverlay + $pageRow;
@@ -395,7 +395,7 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
         if (ExtensionManagementUtility::isLoaded('gridelements')) {
             $where .= ' AND colPos <> -2 ';
             $fields .= ', (SELECT hidden FROM tt_content as t2 WHERE t2.uid = tt_content.tx_gridelements_container)' .
-                       ' as parentGridHidden';
+                ' as parentGridHidden';
         }
 
         $where .= BackendUtility::BEenableFields($table);
@@ -499,9 +499,11 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
             }
         }
 
+
         // store record in index table
         if (count($pageContent)) {
             foreach ($pageContent as $language_uid => $content) {
+                
                 if (!$pageAccessRestrictions['hidden'] && $this->checkIfpageShouldBeIndexed($uid, $language_uid)) {
                     // overwrite access restrictions with language overlay values
                     $accessRestrictionsLanguageOverlay = $pageAccessRestrictions;
@@ -521,6 +523,11 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
                         }
                     }
 
+                    // use new "tx_kesearch_abstract" field instead of "abstract" if set
+                    $abstract = $this->cachedPageRecords[$language_uid][$uid]['tx_kesearch_abstract'] ?
+                        $this->cachedPageRecords[$language_uid][$uid]['tx_kesearch_abstract'] :
+                        $this->cachedPageRecords[$language_uid][$uid]['abstract'];
+
                     $this->pObj->storeInIndex(
                         $indexerConfig['storagepid'],                               // storage PID
                         $this->cachedPageRecords[$language_uid][$uid]['title'],     // page title
@@ -529,7 +536,7 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
                         $content,                        // indexed content, includes the title (linebreak after title)
                         $tags,                                                      // tags
                         $indexEntryDefaultValues['params'],                         // typolink params for singleview
-                        $this->cachedPageRecords[$language_uid][$uid]['abstract'],  // abstract
+                        $abstract,                                                  // abstract
                         $language_uid,                                              // language uid
                         $accessRestrictionsLanguageOverlay['starttime'],            // starttime
                         $accessRestrictionsLanguageOverlay['endtime'],              // endtime

--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -862,7 +862,9 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
 
             case 'page':
                 if ($this->conf['showPageImages']) {
-                    $imageHtml = $this->renderFALPreviewImage($row['orig_uid'], 'pages', 'media');
+                    // use new field "tx_kesearch_resultimage" if set, otherwise field "media"
+                    $imageHtml = $this->renderFALPreviewImage($row['orig_uid'], 'pages', 'tx_kesearch_resultimage');
+                    if (empty($imageHtml)) $imageHtml = $this->renderFALPreviewImage($row['orig_uid'], 'pages', 'media');
                 }
                 break;
 

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,26 @@
+<?php
+defined('TYPO3_MODE') || die();
+
+// add tag field to pages
+$tempColumns = array(
+    'tx_kesearch_tags' => array(
+        'exclude' => 1,
+        'label' => 'LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_tags',
+        'config' => array(
+            'type' => 'select',
+            'renderType' => 'selectSingleBox',
+            'size' => 10,
+            'minitems' => 0,
+            'maxitems' => 100,
+            'items' => array(),
+            'allowNonIdValues' => true,
+            'itemsProcFunc' => 'user_filterlist->getListOfAvailableFiltersForTCA',
+        )
+    ),
+);
+
+TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $tempColumns);
+TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+    'pages',
+    '--div--;LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_label,tx_kesearch_tags;;;;1-1-1'
+);

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -17,9 +17,9 @@ $tempColumns = [
             'itemsProcFunc' => 'user_filterlist->getListOfAvailableFiltersForTCA',
         ]
     ],
-    'tx_kesearch_description' => [
+    'tx_kesearch_abstract' => [
         'exclude' => 1,
-        'label' => 'LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_description',
+        'label' => 'LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_abstract',
         'config' => [
             'type' => 'text',
             'cols' => 40,
@@ -49,5 +49,5 @@ $tempColumns = [
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $tempColumns);
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
     'pages',
-    '--div--;LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_label,tx_kesearch_tags,tx_kesearch_description,tx_kesearch_resultimage;;;;1-1-1'
+    '--div--;LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_label,tx_kesearch_tags,tx_kesearch_abstract,tx_kesearch_resultimage;;;;1-1-1'
 );

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -46,8 +46,12 @@ $tempColumns = [
     ],
 ];
 
+// add new fields to tab "search" and move field "no_search" to "search tab"
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $tempColumns);
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
     'pages',
-    '--div--;LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_label,tx_kesearch_tags,tx_kesearch_abstract,tx_kesearch_resultimage;;;;1-1-1'
+    '--div--;LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_label,no_search;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.no_search_formlabel, tx_kesearch_tags,tx_kesearch_abstract,tx_kesearch_resultimage;;;;1-1-1'
 );
+
+// remove field "no_search" from "miscellaneous" palette
+$GLOBALS['TCA']['pages']['palettes']['miscellaneous']['showitem'] = 'is_siteroot;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.is_siteroot_formlabel, php_tree_stop;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.php_tree_stop_formlabel';

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -2,25 +2,52 @@
 defined('TYPO3_MODE') || die();
 
 // add tag field to pages
-$tempColumns = array(
-    'tx_kesearch_tags' => array(
+$tempColumns = [
+    'tx_kesearch_tags' => [
         'exclude' => 1,
         'label' => 'LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_tags',
-        'config' => array(
+        'config' => [
             'type' => 'select',
             'renderType' => 'selectSingleBox',
             'size' => 10,
             'minitems' => 0,
             'maxitems' => 100,
-            'items' => array(),
+            'items' => [],
             'allowNonIdValues' => true,
             'itemsProcFunc' => 'user_filterlist->getListOfAvailableFiltersForTCA',
+        ]
+    ],
+    'tx_kesearch_description' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_description',
+        'config' => [
+            'type' => 'text',
+            'cols' => 40,
+            'rows' => 15
+        ]
+    ],
+    'tx_kesearch_resultimage' => [
+        'exclude' => true,
+        'label' => 'LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_resultimage',
+        'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
+            'tx_kesearch_resultimage',
+            [
+                'overrideChildTca' => [
+                    'types' => [
+                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
+                            'showitem' => '
+                                    --palette--;LLL:EXT:lang/Resources/Private/Language/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
+                                    --palette--;;filePalette'
+                        ]
+                    ],
+                ],
+            ]
         )
-    ),
-);
+    ],
+];
 
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $tempColumns);
 TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
     'pages',
-    '--div--;LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_label,tx_kesearch_tags;;;;1-1-1'
+    '--div--;LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_label,tx_kesearch_tags,tx_kesearch_description,tx_kesearch_resultimage;;;;1-1-1'
 );

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -42,26 +42,6 @@ TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
     'FILE:EXT:ke_search/pi3/flexform_pi3.xml'
 );
 
-// add tag field to pages
-$tempColumns = array(
-    'tx_kesearch_tags' => array(
-        'exclude' => 1,
-        'label' => 'LLL:EXT:ke_search/locallang_db.xml:pages.tx_kesearch_tags',
-        'config' => array(
-            'type' => 'select',
-            'renderType' => 'selectSingleBox',
-            'size' => 10,
-            'minitems' => 0,
-            'maxitems' => 100,
-            'items' => array(),
-            'allowNonIdValues' => true,
-            'itemsProcFunc' => 'user_filterlist->getListOfAvailableFiltersForTCA',
-        )
-    ),
-);
-TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $tempColumns);
-TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_kesearch_tags;;;;1-1-1');
-
 // add module
 if (TYPO3_MODE == 'BE') {
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,7 +3,7 @@
 #
 CREATE TABLE pages (
 	tx_kesearch_tags text,
-	tx_kesearch_description text,
+	tx_kesearch_abstract text,
 	tx_kesearch_resultimage int(11) unsigned DEFAULT '0' NOT NULL,
 );
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,7 +2,9 @@
 # Table structure for table 'pages'
 #
 CREATE TABLE pages (
-	tx_kesearch_tags text
+	tx_kesearch_tags text,
+	tx_kesearch_description text,
+	tx_kesearch_resultimage int(11) unsigned DEFAULT '0' NOT NULL,
 );
 
 

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -6,6 +6,7 @@
 	</meta>
 	<data type="array">
 		<languageKey index="default" type="array">
+			<label index="pages.tx_kesearch_label">Search</label>
 			<label index="pages.tx_kesearch_tags">Tags for faceted search</label>
 			<label index="tt_content.list_type_pi1">Faceted search - Searchbox and Filters</label>
 			<label index="tt_content.list_type_pi2">Faceted search - Results</label>

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -8,6 +8,8 @@
 		<languageKey index="default" type="array">
 			<label index="pages.tx_kesearch_label">Search</label>
 			<label index="pages.tx_kesearch_tags">Tags for faceted search</label>
+			<label index="pages.tx_kesearch_resultimage">Search result image</label>
+			<label index="pages.tx_kesearch_description">Description for search result</label>
 			<label index="tt_content.list_type_pi1">Faceted search - Searchbox and Filters</label>
 			<label index="tt_content.list_type_pi2">Faceted search - Results</label>
 			<label index="tt_content.list_type_pi3">Faceted search - Multiselect for Textlinks</label>

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -9,7 +9,7 @@
 			<label index="pages.tx_kesearch_label">Search</label>
 			<label index="pages.tx_kesearch_tags">Tags for faceted search</label>
 			<label index="pages.tx_kesearch_resultimage">Search result image</label>
-			<label index="pages.tx_kesearch_description">Description for search result</label>
+			<label index="pages.tx_kesearch_abstract">Abstract for search result</label>
 			<label index="tt_content.list_type_pi1">Faceted search - Searchbox and Filters</label>
 			<label index="tt_content.list_type_pi2">Faceted search - Results</label>
 			<label index="tt_content.list_type_pi3">Faceted search - Multiselect for Textlinks</label>
@@ -95,7 +95,10 @@
 			<label index="tx_kesearch_indexerconfig.cal_expired_events">Index expired events?</label>
 		</languageKey>
 		<languageKey index="de" type="array">
+			<label index="pages.tx_kesearch_label">Suche</label>
 			<label index="pages.tx_kesearch_tags">Schlagworte für facettierte Suche</label>
+			<label index="pages.tx_kesearch_resultimage">Bild für Suchergebnis</label>
+			<label index="pages.tx_kesearch_abstract">Abstract für Suchergebnis</label>
 			<label index="tt_content.list_type_pi1">Facettierte Suche - Suchbox und Filter</label>
 			<label index="tt_content.list_type_pi2">Facettierte Suche - Ergebnisliste</label>
 			<label index="tt_content.list_type_pi3">Facettierte Suche - Mehrfachauswahl für Textlinks</label>

--- a/pi1/flexform_pi1.xml
+++ b/pi1/flexform_pi1.xml
@@ -257,7 +257,7 @@
 									</numIndex>
 								</items>
 								<size>1</size>
-								<default>hit</default>
+								<default>abstract</default>
 							</config>
 						</TCEforms>
 					</previewMode>


### PR DESCRIPTION
- create new tab "search" in page record
- Add new fields "abstract" and "image" to pages
- move field "tags for faceted search" to new tab
- move tca additions for pages to config/tca/overrides/pages
- remove field "no_search" from palette "miscellaneous" and add field to search tab
- use new abstract field for indexing, fallback to old abstract field
- use new image file in result list, fallback to media field