### PR TITLE
[TASK] Change orig_uid field to varchar

### DIFF
--- a/Classes/indexer/class.tx_kesearch_indexer.php
+++ b/Classes/indexer/class.tx_kesearch_indexer.php
@@ -671,7 +671,7 @@ class tx_kesearch_indexer
      * This function also sets $this->currentRow
      * parameters should be already fullQuoted. see storeInIndex
      * TODO: We should create an index to column type
-     * @param integer $uid
+     * @param string $uid
      * @param integer $pid
      * @param string $type
      * @param integer $language

--- a/Classes/lib/class.tx_kesearch_lib.php
+++ b/Classes/lib/class.tx_kesearch_lib.php
@@ -1116,7 +1116,7 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      * renders the preview image of a result which has an attached image,
      * needs FAL and is therefore only available for TYPO3 version 6 or higher.
      * Returns an empty string if no image could be rendered.
-     * @param integer $uid uid of referencing record
+     * @param string $uid uid of referencing record
      * @param string $table table name of the original table
      * @param string $fieldname field which holds the FAL reference
      * @author Christian Bülter <christian.buelter@inmedias.de>
@@ -1336,7 +1336,7 @@ class tx_kesearch_lib extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
     }
 
     /**
-     * @param $eventUid
+     * @param string $eventUid The uid is passed as string, but we know that for Cal this is an integer
      * @return array
      */
     public function getCalEventEnddate($eventUid)

--- a/Classes/lib/class.tx_kesearch_lib_helper.php
+++ b/Classes/lib/class.tx_kesearch_lib_helper.php
@@ -242,7 +242,7 @@ class tx_kesearch_helper
     }
 
     /**
-     * @param integer $uid
+     * @param string $uid
      * @return \TYPO3\CMS\Core\Resource\File|NULL
      */
     public static function getFile($uid)

--- a/Tests/indexer/class.tx_kesearch_indexerTest.php
+++ b/Tests/indexer/class.tx_kesearch_indexerTest.php
@@ -32,14 +32,14 @@ class IndexerTest extends Tx_Extbase_BaseTestCase
             'tstamp' => $now,
             'crdate' => $now,
             'title' => 'tolle Überschrift',
-            'orig_uid' => 213,
+            'orig_uid' => '213asdf',
             'orig_pid' => 423,
             'enddate' => $now,
         );
         $fieldValues = $GLOBALS['TYPO3_DB']->fullQuoteArray($fieldValues, 'tx_kesearch_index');
 
         $shouldArray = array(
-            'set' => ', @orig_uid = \'213\', @orig_pid = \'423\', @enddate = \'' . $now . '\'',
+            'set' => ', @orig_uid = \'213asdf\', @orig_pid = \'423\', @enddate = \'' . $now . '\'',
             'execute' => ', @orig_uid, @orig_pid, @enddate'
         );
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -4,7 +4,7 @@
 CREATE TABLE pages (
 	tx_kesearch_tags text,
 	tx_kesearch_abstract text,
-	tx_kesearch_resultimage int(11) unsigned DEFAULT '0' NOT NULL,
+	tx_kesearch_resultimage int(11) unsigned DEFAULT '0' NOT NULL
 );
 
 
@@ -82,7 +82,7 @@ CREATE TABLE tx_kesearch_index (
 	tags text,
 	abstract text,
 	sortdate int(11) DEFAULT '0' NOT NULL,
-	orig_uid int(11) DEFAULT '0' NOT NULL,
+	orig_uid varchar(255) DEFAULT '0' NOT NULL,
 	orig_pid int(11) DEFAULT '0' NOT NULL,
 	title tinytext,
 	language int(11) DEFAULT '0' NOT NULL,
@@ -166,5 +166,5 @@ CREATE TABLE tx_kesearch_stat_word (
   pageid int(11) DEFAULT '0' NOT NULL,
   resultsfound int(1) DEFAULT '0' NOT NULL,
   language int(11) DEFAULT '0' NOT NULL,
-  PRIMARY KEY (uid),
+  PRIMARY KEY (uid)
 );


### PR DESCRIPTION
Making the orig_uid field a varchar allows custom indexers to store
guid or any other form of unique id into this field. Those ids may
stem from external systems.