### PR TITLE
Feature/news skip controller and action

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_news.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_news.php
@@ -175,8 +175,11 @@ class tx_kesearch_indexer_types_news extends tx_kesearch_indexer_types
                             ? $newsRecord['l10n_parent']
                             : $newsRecord['uid']
                         ;
-                        $paramsSingleView['tx_news_pi1']['controller'] = 'News';
-                        $paramsSingleView['tx_news_pi1']['action'] = 'detail';
+						// skips controller and action
+						if($indexerConfig['index_news_skip_controller_action'] == 0) {
+							$paramsSingleView['tx_news_pi1']['controller'] = 'News';
+							$paramsSingleView['tx_news_pi1']['action'] = 'detail';
+						}
                         $params = '&' . http_build_query($paramsSingleView, null, '&');
                         $params = rawurldecode($params);
                     }

--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_news.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_news.php
@@ -175,11 +175,11 @@ class tx_kesearch_indexer_types_news extends tx_kesearch_indexer_types
                             ? $newsRecord['l10n_parent']
                             : $newsRecord['uid']
                         ;
-						// skips controller and action
-						if($indexerConfig['index_news_skip_controller_action'] == 0) {
-							$paramsSingleView['tx_news_pi1']['controller'] = 'News';
-							$paramsSingleView['tx_news_pi1']['action'] = 'detail';
-						}
+                        // skips controller and action
+                        if($indexerConfig['index_news_skip_controller_action'] == 0) {
+                            $paramsSingleView['tx_news_pi1']['controller'] = 'News';
+                            $paramsSingleView['tx_news_pi1']['action'] = 'detail';
+                        }
                         $params = '&' . http_build_query($paramsSingleView, null, '&');
                         $params = rawurldecode($params);
                     }

--- a/Configuration/TCA/tx_kesearch_indexerconfig.php
+++ b/Configuration/TCA/tx_kesearch_indexerconfig.php
@@ -302,6 +302,15 @@ $configurationArray = array(
                 'maxitems' => 1,
             )
         ),
+        'index_news_skip_controller_action' => array(
+            'exclude' => 0,
+            'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.index_news_skip_controller_action',
+            'displayCond' => 'FIELD:type:IN:news',
+            'config' => array(
+                'type' => 'check',
+                'default' => '0'
+            )
+        ),
         'index_news_category_selection' => array(
             'exclude' => 1,
             'label' => 'LLL:EXT:ke_search/locallang_db.xml:tx_kesearch_indexerconfig.index_news_category_selection',
@@ -464,7 +473,7 @@ $configurationArray = array(
     'types' => array(
         '0' => array('showitem' => 'hidden, title, storagepid,targetpid,type,'
             . 'startingpoints_recursive,single_pages,sysfolder,index_content_with_restrictions,index_passed_events,'
-            . 'index_news_archived,index_news_category_mode,index_news_category_selection,'
+            . 'index_news_archived,index_news_skip_controller_action,index_news_category_mode,index_news_category_selection,'
             . 'index_extnews_category_selection,index_news_useHRDatesSingle,index_news_useHRDatesSingleWithoutDay,'
             . 'index_use_page_tags,fal_storage,directories,fileext,index_page_doctypes,contenttypes,commenttypes,'
             . 'filteroption,tvpath,index_use_page_tags_for_files,cal_expired_events')

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -119,6 +119,7 @@ CREATE TABLE tx_kesearch_indexerconfig (
 	index_content_with_restrictions text,
 	index_passed_events text,
 	type varchar(90) DEFAULT '' NOT NULL,
+	index_news_skip_controller_action tinyint(4) DEFAULT '0' NOT NULL,
 	index_news_category_mode tinyint(4) DEFAULT '0' NOT NULL,
 	index_news_category_selection text,
 	index_extnews_category_selection text,

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -76,6 +76,7 @@
 			<label index="tx_kesearch_indexerconfig.index_news_archived.I.0">Index all news</label>
 			<label index="tx_kesearch_indexerconfig.index_news_archived.I.1">Index only active news</label>
 			<label index="tx_kesearch_indexerconfig.index_news_archived.I.2">Index only archived news</label>
+			<label index="tx_kesearch_indexerconfig.index_news_skip_controller_action">Removing controller and action arguments from URL</label>
 			<label index="tx_kesearch_indexerconfig.index_news_category_selection">Categories:</label>
 			<label index="tx_kesearch_indexerconfig.index_news_useHRDatesSingleWithoutDay">Use dates without day for single-view-URLs:</label>
 			<label index="tx_kesearch_indexerconfig.index_use_page_tags">Add tags of parent pages/sys-folders?</label>
@@ -161,6 +162,7 @@
 			<label index="tx_kesearch_indexerconfig.index_news_category_mode">News der folgenden Kategorien indexieren:</label>
 			<label index="tx_kesearch_indexerconfig.index_news_category_mode.I.1">Alle</label>
 			<label index="tx_kesearch_indexerconfig.index_news_category_mode.I.2">Nur die folgenden Kategorien:</label>
+			<label index="tx_kesearch_indexerconfig.index_news_skip_controller_action">Controller- und Aktionsargumente aus der URL entfernen</label>
 			<label index="tx_kesearch_indexerconfig.index_news_category_selection">Kategorien:</label>
 			<label index="tx_kesearch_indexerconfig.index_extnews_category_selection">Kategorien:</label>
 			<label index="tx_kesearch_indexerconfig.index_news_useHRDatesSingle">Datum in Single-View-URLs:</label>


### PR DESCRIPTION
Added checkbox to remove controller and action arguments from the URL (&tx_news_pi1[controller]=News&tx_news_pi1[action]=detail).
This function is compareable with "plugin.tx_news.settings.link.skipControllerAndAction" setting.