### PR TITLE
Workaround for flexform setting 'resultLinkTargetFiles' being ignored

### DIFF
--- a/Classes/lib/class.tx_kesearch_lib_searchresult.php
+++ b/Classes/lib/class.tx_kesearch_lib_searchresult.php
@@ -100,6 +100,9 @@ class tx_kesearch_lib_searchresult
                 } else {
                     $linktext = $this->row['title'];
                 }
+                // $linkconf['fileTarget'] is ignored so add it to the parameter if set
+                if (isset ($linkconf['fileTarget']))
+                	$linkconf['parameter'] .= ' ' . $linkconf['fileTarget'];
                 break;
             default:
                 $linktext = $this->row['title'];


### PR DESCRIPTION
$linkconf['fileTarget'] (originating from plugin flexform setting 'resultLinkTargetFiles') is ignored by $this->cObj->typoLink($linktext, $linkconf) in line 120.
Workaround is to add the file target to the parameter string.