### PR TITLE
[BUGFIX] ignore pages with no_search flag in pages indexer

### DIFF
--- a/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
+++ b/Classes/indexer/types/class.tx_kesearch_indexer_types_page.php
@@ -292,7 +292,7 @@ class tx_kesearch_indexer_types_page extends tx_kesearch_indexer_types
     {
         $fields = '*';
         $table = 'pages';
-        $where = 'uid IN (' . implode(',', $uids) . ')';
+        $where = 'uid IN (' . implode(',', $uids) . ') AND no_search <> 1';
 
         $pages = array();
         $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery($fields, $table, $where);


### PR DESCRIPTION
When using the tt_content indexer the content from pages with the no_search flag set are also included in the index. 

With this PR the no_search pages are not included in the indexer run.