### PR TITLE
Remove type casting from already fully quoted variable

### DIFF
--- a/Classes/indexer/class.tx_kesearch_indexer.php
+++ b/Classes/indexer/class.tx_kesearch_indexer.php
@@ -710,7 +710,7 @@ class tx_kesearch_indexer
     {
         // Query DB if record already exists
         $res = $GLOBALS['TYPO3_DB']->sql_query(
-            'SELECT * FROM tx_kesearch_index WHERE ' . 'type = ' . $type . ' AND hash = ' . $hash . ' AND pid = ' . (int) $pid . ' LIMIT 1'
+            'SELECT * FROM tx_kesearch_index WHERE ' . 'type = ' . $type . ' AND hash = ' . $hash . ' AND pid = ' . $pid . ' LIMIT 1'
         );
         if ($GLOBALS['TYPO3_DB']->sql_num_rows($res)) {
             if ($this->currentRow = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {


### PR DESCRIPTION
The variable $pid is already fully quoted in method createFieldValuesForIndexing. A value of 1234 will be '1234' after quoting. Type casting a string value like '1234' to integer will always return zero because of the quotes. There simply is no need for type casting here.