### PR TITLE
Use !empty instead of count

### DIFF
--- a/Classes/indexer/class.tx_kesearch_indexer_types.php
+++ b/Classes/indexer/class.tx_kesearch_indexer_types.php
@@ -141,7 +141,7 @@ class tx_kesearch_indexer_types
         $where .= BackendUtility::BEenableFields($table);
         $where .= BackendUtility::deleteClause($table);
         $this->pageRecords = $this->getPageRecords($indexPids, $where, 'pages,' . $table, 'pages.*');
-        if (count($this->pageRecords)) {
+        if (!empty($this->pageRecords)) {
             // create a new list of allowed pids
             return array_keys($this->pageRecords);
         } else {


### PR DESCRIPTION
To prevent warning in php 7.2