### PR TITLE
[BUGFIX] Initialize array to avoid PHP warning

### DIFF
--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -1253,7 +1253,7 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      */
     public function sortArrayByColumn(&$arr, $col)
     {
-
+        $newArray = [];
         $sort_col = array();
         foreach ($arr as $key => $row) {
             $sort_col[$key] = strtoupper($row[$col]);


### PR DESCRIPTION
The sort function is used in a place which relies on the $arr
param to be an array as a count() is run on it.
Make sure the function always returns an array.