### PR TITLE
[FIX] custom indexer fails in TYPO3 9.5 in case of missing field @s…

### DIFF
--- a/Classes/Indexer/IndexerRunner.php
+++ b/Classes/Indexer/IndexerRunner.php
@@ -664,6 +664,7 @@ class IndexerRunner
 			@endtime = ' . $queryBuilder->quote($fieldValues['endtime'], \PDO::PARAM_INT) . ',
 			@fe_group = ' . $queryBuilder->quote($fieldValues['fe_group'], \PDO::PARAM_INT) . ',
 			@tstamp = ' . $queryBuilder->quote($fieldValues['tstamp'], \PDO::PARAM_INT) . ',
+			@sortdate = ' . $queryBuilder->quote($fieldValues['sortdate'], \PDO::PARAM_INT) . ',
 			@crdate = ' . $queryBuilder->quote($fieldValues['crdate'], \PDO::PARAM_INT)
             . $addQueryPartFor['set'] . '
 		;';
@@ -682,6 +683,7 @@ class IndexerRunner
             . '@endtime, '
             . '@fe_group, '
             . '@tstamp, '
+            . '@sortdate, '
             . '@crdate'
             . $addQueryPartFor['execute'] . ';';
 


### PR DESCRIPTION
In TYPO3 9.5 the custom indexer fails (exception: missing field @sortdate).