### PR TITLE
#280 Fix max results per page on mySQL search

### DIFF
--- a/Classes/Lib/Db.php
+++ b/Classes/Lib/Db.php
@@ -105,7 +105,7 @@ class Db implements \TYPO3\CMS\Core\SingletonInterface
 
         $limit = $this->getLimit();
         if (is_array($limit)) {
-            $resultQuery->setMaxResults(10);
+            $resultQuery->setMaxResults($limit[1]);
             $resultQuery->setFirstResult($limit[0]);
         }
 


### PR DESCRIPTION
#280 This fixes the maximum 10 results that are hard coded in the getSearchResultByMySQL() function