### PR TITLE
Searchword statistics: folder exclusion does not take effect

### DIFF
--- a/Classes/Controller/BackendModuleController.php
+++ b/Classes/Controller/BackendModuleController.php
@@ -655,6 +655,9 @@ class BackendModuleController extends AbstractBackendModuleController
         // get data from sysfolder or from single page?
         $isSysFolder = $this->checkSysfolder();
 
+        // set folder or single page where the data is selected from
+        $pidWhere = $isSysFolder ? ' AND pid=' . intval($pageUid) . ' ' : ' AND pageid=' . intval($pageUid) . ' ';
+
         // get languages
         $queryBuilder = Db::getQueryBuilder('tx_kesearch_stat_word');
         $queryBuilder->getRestrictions()->removeAll();


### PR DESCRIPTION
In the **current Version 3.1.1** the "Searchword statistics" always show all results from the previous 30 days, no matter which folder is selected. 
This is caused by the BackendModuleController. The function "getSearchwordStatistics" does not create a $pidWhere variable. In **Version 2.8.2** it was created by the following line of code: 

`$pidWhere = $isSysFolder ? ' AND pid=' . intval($pageUid) . ' ' : ' AND pageid=' . intval($pageUid) . ' ';`

Now this line does not exist anymore, which causes the query to only consider language and timestamp. After inserting this line again the "Searchword statistics" excludes none selected folders again.