### PR TITLE
[BUGFIX] fix missing tablename and wrong select arguments for cal events

### DIFF
--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -1168,9 +1168,10 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      */
     public function getCalEventEnddate($eventUid)
     {
+        $table = 'tx_cal_event';
         $queryBuilder = Db::getQueryBuilder($table);
         $row = $queryBuilder
-            ->select('end_date, end_time, allday, start_date')
+            ->select('end_date', 'end_time', 'allday', 'start_date')
             ->from($table)
             ->where(
                 $queryBuilder->expr()->eq(


### PR DESCRIPTION
When using ext:cal events
The variable $table in method getCalEventEnddate is null.
Fixes error: 
```
(1/1) TypeError
Argument 1 passed to TYPO3\CMS\Core\Database\ConnectionPool::getQueryBuilderForTable() must be of the type string, null given, called in /var/www/vhosts/wpv/web/typo3conf/ext/ke_search/Classes/Lib/Db.php on line 530
```
