### PR TITLE
[FIX] Always Hook modifyPagesIndexEntry

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -616,7 +616,6 @@ class Page extends IndexerBase
             }
         } else {
             $this->counterWithoutContent++;
-            return;
         }
 
         // make it possible to modify the indexerConfig via hook


### PR DESCRIPTION
Execution of  hook `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyPagesIndexEntry']` is skipped, if the current page has no `tt_content` records. This makes it impossible to hook empty pages.
But empty pages need to be hooked if you for example try to implement correct `content_from_pid` handling.