### PR TITLE
[TASK] move addPiFlexFormValue calls to TCA overrides

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -31,3 +31,14 @@ TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
     'list_type',
     'ke_search'
 );
+
+// Configure FlexForm field
+TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    $_EXTKEY . '_pi1',
+    'FILE:EXT:ke_search/Configuration/FlexForms/flexform_searchbox.xml'
+);
+
+TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    $_EXTKEY . '_pi2',
+    'FILE:EXT:ke_search/Configuration/FlexForms/flexform_resultlist.xml'
+);

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -12,17 +12,6 @@ TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr(
     'EXT:ke_search/locallang_csh.xml'
 );
 
-// Configure FlexForm field
-TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-    $_EXTKEY . '_pi1',
-    'FILE:EXT:ke_search/Configuration/FlexForms/flexform_searchbox.xml'
-);
-
-TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-    $_EXTKEY . '_pi2',
-    'FILE:EXT:ke_search/Configuration/FlexForms/flexform_resultlist.xml'
-);
-
 // add module
 if (TYPO3_MODE == 'BE') {
 


### PR DESCRIPTION
ExtensionManagementUtility::addPiFlexFormValue must not be called in ext_tables.php as it modifies TCA globally