### PR TITLE
[DOCS] Fix typos

### DIFF
--- a/Documentation/Behaviour/Ranking.rst
+++ b/Documentation/Behaviour/Ranking.rst
@@ -59,5 +59,6 @@ top of the list, consider the premium version of ke_search which adds the featur
 and "boost keywords".
 
 More information
+
 * http://dev.kesearch.de/documentation/ke_search_premium/Index.html
 * https://www.typo3-macher.de/facettierte-suche-ke-search/premium/

--- a/Documentation/CommandLine/Index.rst
+++ b/Documentation/CommandLine/Index.rst
@@ -16,7 +16,7 @@ Start the indexer
 
 .. code-block:: none
 
-	bin/typo3 ke_search:index
+	bin/typo3 ke_search:indexing
 
 .. image:: ../Images/CommandLine/cli-start-indexing.png
 

--- a/Documentation/Filters/Index.rst
+++ b/Documentation/Filters/Index.rst
@@ -20,7 +20,7 @@ Example
 Example "Car Website"
 .....................
 
-You have a website that's about cars. On a some pages, your content is about tires, others are about "Accessories".
+You have a website that's about cars. On some pages, your content is about tires, others are about "Accessories".
 You can now create a filter named "Accessories" and filter option named "Tires". Now when your customer
 uses the search function, she or he can narrow down the search to all pages marked with "Tires". That does not
 mean, that "Tires" must be on that page as a word, but it's marked as "relevant for tires" in the backend.

--- a/Documentation/Hooks/Index.rst
+++ b/Documentation/Hooks/Index.rst
@@ -8,7 +8,7 @@
 Hooks
 =====
 
-ke_search includes a lot of hooks you can use to include your own code and custumize the behaviour of the extension.
+ke_search includes a lot of hooks you can use to include your own code and customize the behaviour of the extension.
 
 modifyPagesIndexEntry
 	Use this hook to modify the page data just before it will be saved into database.
@@ -35,7 +35,7 @@ customFilterRenderer
 	You can write your own filter rendering function using this hook. You will have to add your custom filter type to TCA options array. See chapter “Custom filter rendering” for further information.
 
 registerIndexerConfiguration
-	Use this hook for registering your custom indexer configuration in TCA. See chapter “Write your own custom indexer!” for further information.
+	Use this hook for registering your custom indexer configuration in TCA. See chapter “:ref:`Write your own custom indexer! <customIndexer>`” for further information.
 
 registerAdditionalFields
 	This hook is important if you have extended the indexer table with your own columns.

--- a/Documentation/Indexing/Index.rst
+++ b/Documentation/Indexing/Index.rst
@@ -23,7 +23,7 @@ Configure the indexer configuration:
 
 The other indexer configurations options differ from type to type.
 
-Whenever the content in your website changes, the indexing process will have to be startet to reflect that changes in
+Whenever the content in your website changes, the indexing process will have to be started to reflect that changes in
 the search result.
 
 Manual indexing

--- a/Documentation/Indexing/IndexerTypes/Pages.rst
+++ b/Documentation/Indexing/IndexerTypes/Pages.rst
@@ -15,6 +15,7 @@ word appears in two different text elements on a page, you will get only one sea
 these two elements belong to.
 
 The page indexer indexes content elements of the following types:
+
 * text
 * text with image
 * bullet list
@@ -41,4 +42,4 @@ Advanced options:
 * Set the page types you want to index.
 * Set the content element types you want to index. You can add your own content element types for example those created with the extension "mask".
 * You can choose to add a tag to all index entries created by this indexer.
-* You can choos to add that tag also to files indexed by this indexer.
+* You can choose to add that tag also to files indexed by this indexer.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -21,7 +21,7 @@
 # ...   (required) title (displayed in left sidebar (desktop) or top panel (mobile)
 # .................................................................................
 
-project     = {extension.name}
+project     = ke_search
 
 # .................................................................................
 # ...   (recommended) version, displayed next to title (desktop) and in <meta name="book-version"


### PR DESCRIPTION
Additionally:
- Show lists as lists (empty line before the list)
- Correct ke_search:indexing command call
- Link from hooks to chapter custom indexer
- Set project name (so it's shown correctly in the docs header)