### PR TITLE
Load the selectd category UID of the news indexer (Issue #363)

### DIFF
--- a/Classes/Indexer/Filetypes/Pdf.php
+++ b/Classes/Indexer/Filetypes/Pdf.php
@@ -41,6 +41,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Pdf extends File implements FileIndexerInterface
 {
+    
     public $extConf = array(); // saves the configuration of extension ke_search_hooks
     public $app = array(); // saves the path to the executables
     public $isAppArraySet = false;
@@ -124,8 +125,7 @@ class Pdf extends File implements FileIndexerInterface
                 unlink($tempFileName);
             } else {
                 $errorMessage = 'Content for file ' . $file . ' could not be extracted. Maybe it is encrypted?';
-                $runner = GeneralUtility::makeInstance(IndexerRunner::class);
-                $runner->logger->error($errorMessage);
+                $this->pObj->logger->warning($errorMessage);
                 $this->addError($errorMessage);
 
                 // return empty string if no content was found

--- a/Classes/Indexer/Filetypes/Pdf.php
+++ b/Classes/Indexer/Filetypes/Pdf.php
@@ -41,7 +41,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Pdf extends File implements FileIndexerInterface
 {
-
     public $extConf = array(); // saves the configuration of extension ke_search_hooks
     public $app = array(); // saves the path to the executables
     public $isAppArraySet = false;
@@ -125,7 +124,8 @@ class Pdf extends File implements FileIndexerInterface
                 unlink($tempFileName);
             } else {
                 $errorMessage = 'Content for file ' . $file . ' could not be extracted. Maybe it is encrypted?';
-                $this->pObj->logger->warning($errorMessage);
+                $runner = GeneralUtility::makeInstance(IndexerRunner::class);
+                $runner->logger->error($errorMessage);
                 $this->addError($errorMessage);
 
                 // return empty string if no content was found

--- a/Classes/Indexer/IndexerBase.php
+++ b/Classes/Indexer/IndexerBase.php
@@ -380,4 +380,39 @@ class IndexerBase
         return $this->errors;
     }
 
+    /**
+     * get the sys_category UIDs which 
+     * are selected in an indexer configurationn
+     * @param int $indexerConfigUid
+     * @return array $selectedCategories
+     */
+    public function getCategoryConfiguration(int $indexerConfigUid): array
+    {
+        $queryBuilder = Db::getQueryBuilder('sys_category_record_mm');
+        $selectedCategories = $queryBuilder
+            ->select('uid_local')
+            ->from('sys_category_record_mm')
+            ->where(
+                $queryBuilder->expr()->eq('uid_foreign', $queryBuilder->createNamedParameter($indexerConfigUid, \PDO::PARAM_INT)),
+                $queryBuilder->expr()->eq('tablenames', $queryBuilder->createNamedParameter('tx_kesearch_indexerconfig'))
+            )
+            ->execute()
+            ->fetchAll();
+        
+        if ($selectedCategories) {
+            // flatten the multidimensional array 
+            // to only conntain the category UIDs
+            $flattenSelectedCategories = [];
+            array_walk_recursive($selectedCategories, function ($a) use (&$flattenSelectedCategories) {
+                $flattenSelectedCategories[] = $a;
+            });
+            $selectedCategories = $flattenSelectedCategories;
+        } else {
+            // make sure to return an empty array
+            // in case the query returns NULL
+            $selectedCategories = [];
+        }
+        
+        return $selectedCategories;
+    }
 }

--- a/Classes/Indexer/Types/News.php
+++ b/Classes/Indexer/Types/News.php
@@ -141,16 +141,16 @@ class News extends IndexerBase
                 // assigned that should be indexed.
                 // mode 1 means 'index all news no matter what category
                 // they have'
-                if ($this->indexerConfig['index_news_category_mode'] == '2') {
+                if ($this->indexerConfig['index_news_category_mode'] == '2' && $this->indexerConfig['index_extnews_category_selection']) {
+
+                    // load category configuratio
+                    $selectedCategoryUids = $this->getCategoryConfiguration($this->indexerConfig['uid']);
+
                     $isInList = false;
                     foreach ($categoryData['uid_list'] as $catUid) {
                         // if category was found in list, set isInList
                         // to true and break further processing.
-                        if (GeneralUtility::inList(
-                            $this->indexerConfig['index_extnews_category_selection'],
-                            $catUid
-                        )
-                        ) {
+                        if (in_array($catUid, $selectedCategoryUids)) {
                             $isInList = true;
                             break;
                         }


### PR DESCRIPTION
**Problem**
Using the “News Indexer” of ke_search 3.1.6:

When selecting a category, the value of  `$this->indexerConfig['index_extnews_category_selection']` in the indexer is
 `1` if any category is selected
 `0` if no category is selected

But the value should be the UIDs of the selected categories.

**FIX**
This fix will load the category UIDs which are selected in the news index configuration and compares if the news record is assigned to the selected category before indexing the record.
