### PR TITLE
Prevent hidden files from beeing indexed

### DIFF
--- a/Classes/Indexer/Types/Page.php
+++ b/Classes/Indexer/Types/Page.php
@@ -774,7 +774,7 @@ class Page extends IndexerBase
         if (!in_array($this->cachedPageRecords[$language_uid][$uid]['doktype'], $this->indexDokTypes)) {
             $index = false;
         }
-        
+
         if ((int) $language_uid === 0 && GeneralUtility::hideIfDefaultLanguage($this->cachedPageRecords[$language_uid][$uid]['l18n_cfg'])) {
             $index = false;
         }
@@ -858,8 +858,10 @@ class Page extends IndexerBase
         if (count($fileObjects) && $feGroups != DONOTINDEX) {
             // loop through files
             foreach ($fileObjects as $fileObject) {
+                $isHidden = false;
                 $isInList = false;
                 if ($fileObject instanceof FileInterface) {
+                    $isHidden = $fileObject->hasProperty('hidden') && $fileObject->getProperty('hidden') === 1;
                     $isInList = \TYPO3\CMS\Core\Utility\GeneralUtility::inList(
                         $this->indexerConfig['fileext'],
                         $fileObject->getExtension()
@@ -872,7 +874,7 @@ class Page extends IndexerBase
 
                 // check if the file extension fits in the list of extensions
                 // to index defined in the indexer configuration
-                if ($isInList) {
+                if (!$isHidden && $isInList) {
                     // get file path and URI
                     $filePath = $fileObject->getForLocalProcessing(false);
 


### PR DESCRIPTION
Hidden files were indexed for File List content element.

For content elements in the class property fileCTypes the method "attachedFiles()" is called that uses internal the files processor of TYPO3 (see https://github.com/teaminmedias-pluswerk/ke_search/blob/922cb0051e8e7b90d946cde7205c723267bc016a/Classes/Indexer/Types/Page.php#L937).

The TYPO3 Core FilesCollector class uses than the Method findByRelation() from the FilesRepository but the FilesRepository only uses the FrontendRestriction if your environment is on FE (see https://github.com/TYPO3/TYPO3.CMS/blob/10.4/typo3/sysext/core/Classes/Resource/FileRepository.php#L71). Therefore during backend processing all attached files are written to the search index (also the hidden ones).

Thanks in advance! 😄 
Andi
