### PR TITLE
[DOC] Add link to category filter options in news indexing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ Upcoming version
 [TASK]    Log search query to logfile if configured in plugin settings. https://github.com/teaminmedias-pluswerk/ke_search/issues/321
 [TASK]    Use class name in indexer report if title is not available.
 [TASK]    Show only filter option records for default language in localized pages. https://github.com/teaminmedias-pluswerk/ke_search/issues/367
+[DOC]     Add link to category filter options in news indexing. https://github.com/teaminmedias-pluswerk/ke_search/pull/377
 
 Version 3.2.0, September 2020
 [!!!]     This version changes the database structure!

--- a/Documentation/Indexing/IndexerTypes/News.rst
+++ b/Documentation/Indexing/IndexerTypes/News.rst
@@ -41,6 +41,8 @@ For categories there will also be tags which are based on the string "syscat" an
 
 .. image:: ../../Images/Indexing/indexing-news-tags-2.png
 
+To automatically create and update filters for these tags, see :ref:`systemcategories`.
+
 In the indexer configuration you can set a target page. When a news appears in the result list, the link will go to
 that page. On that page there has to be a news plugin showing the detail view.
 


### PR DESCRIPTION
Adds a link in the indexing page of news.
This allows the reader to quickly find / not overlook this feature.