### PR TITLE
Feature: add allowEmptySearch setting

### DIFF
--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -265,7 +265,7 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
 
         // perform search at this point already if we need to calculate what
         // filters to display.
-        if ($this->conf['checkFilterCondition'] != 'none') {
+        if ($this->conf['checkFilterCondition'] != 'none' && !$this->allowEmptySearch()) {
             $this->db->getSearchResults();
         }
 
@@ -665,6 +665,10 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      */
     public function getSearchResults()
     {
+        if($this->isEmptySearch() && !$this->allowEmptySearch()) {
+            return;
+        }
+
         // fetch the search results
         $limit = $this->db->getLimit();
         $rows = $this->db->getSearchResults();
@@ -1304,5 +1308,16 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
         }
 
         $arr = $newArray;
+    }
+
+    private function allowEmptySearch()
+    {
+        /*
+         * check for inequality to null to maintain functionality even if unset
+         */
+        if ($this->extConf['allowEmptySearch'] != null && $this->extConf['allowEmptySearch'] == false) {
+            return false;
+        }
+        return true;
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -11,7 +11,7 @@ enablePartSearch = 1
 enableExplicitAnd = 0
 
 # cat=basic//50; type=boolean; label=If set to false no query is executed when loading a page with a result list and empty searches deliever no results.
-allowEmptySearch = 0
+allowEmptySearch = 1
 
 # cat=notification//10; type=boolean; label= Send notification when finished: If activated, a notification email will be sent when indexing process is finished in CLI / scheduler mode.
 finishNotification = 0

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -10,6 +10,9 @@ enablePartSearch = 1
 # cat=basic//40; type=boolean; label=Enable explicit AND: By default, one or more searchwords are connected with "OR". If this option is enabled, two or more search words are connected with AND. If it is disabled, they are connected with OR, where results containing all the search words will get a higher relevance ranking. Enabling this function means, ke_search internally adds a "+" in front of each search word.
 enableExplicitAnd = 0
 
+# cat=basic//50; type=boolean; label=If set to false no query is executed when loading a page with a result list and empty searches deliever no results.
+allowEmptySearch = 0
+
 # cat=notification//10; type=boolean; label= Send notification when finished: If activated, a notification email will be sent when indexing process is finished in CLI / scheduler mode.
 finishNotification = 0
 


### PR DESCRIPTION
- if set no query is run when loading a page with result list or an empty search was started

