### PR TITLE
Add section 'extra' because of composer warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     "classmap": [
       "Classes"
     ]
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "ke_search"
+    }
   }
 }


### PR DESCRIPTION
```TYPO3 Extension Package "teaminmedias-pluswerk/ke_search", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)```