### PR TITLE
Move css file to typoscript configuration

### DIFF
--- a/Configuration/FlexForms/flexform_searchbox.xml
+++ b/Configuration/FlexForms/flexform_searchbox.xml
@@ -32,7 +32,6 @@
 							<label>LLL:EXT:ke_search/Resources/Private/Language/locallang_searchbox.xml:ff.cssFile</label>
 							<config>
 								<type>input</type>
-								<default>EXT:ke_search/Resources/Public/Css/ke_search_pi1.css</default>
 								<eval>trim</eval>
 							</config>
 						</TCEforms>

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -17,6 +17,7 @@ plugin.tx_kesearch_pi1 {
             0 = EXT:ke_search/Resources/Private/Layouts/
             1 = {$plugin.tx_kesearch.layoutRootPath}
         }
+        cssFile = EXT:ke_search/Resources/Public/Css/ke_search_pi1.css
     }
 }
 


### PR DESCRIPTION
Its confusing that you have to delete the css file if you have defined the styles somewhere else.