### PR TITLE
[TASK] Allow filters to be rendered in ResultList

### DIFF
--- a/Classes/Lib/Pluginbase.php
+++ b/Classes/Lib/Pluginbase.php
@@ -638,6 +638,9 @@ class Pluginbase extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
         if($this->isEmptySearch() && !$this->allowEmptySearch()) {
             return;
         }
+        
+        // get filters
+        $this->renderFilters();
 
         // fetch the search results
         $limit = $this->db->getLimit();


### PR DESCRIPTION
Adds the option to include the Filters partial in the the ResultList plugin

I wanted to add the link filters to the right-hand side of the search ([Like this](https://www.liquidlight.co.uk/search/?query=google) - note: not using ke_search).

Calling this method inside the `getSearchResults` method, means I can use a custom filter partial to only show the link filters if present